### PR TITLE
Adding obfuscated string

### DIFF
--- a/libs/AJut.Core/Security/CryptoObfuscation.cs
+++ b/libs/AJut.Core/Security/CryptoObfuscation.cs
@@ -90,5 +90,10 @@
                 }
             }
         }
+
+        public static string Decrypt (ObfuscatedString toDecrypt, string key = null)
+        {
+            return CryptoObfuscation.Decrypt(toDecrypt.Active, key);
+        }
     }
 }

--- a/libs/AJut.Core/Security/ObfuscatedString.cs
+++ b/libs/AJut.Core/Security/ObfuscatedString.cs
@@ -1,0 +1,24 @@
+﻿namespace AJut.Security
+{
+    using System;
+
+    /// <summary>
+    /// Storage for encrypted obfuscated strings, stores both the basic string, and the x64 compiled version and provides whichever is active.
+    /// </summary>
+    public class ObfuscatedString
+    {
+        private readonly string m_str;
+        private readonly string m_x64Str;
+
+        public ObfuscatedString (string str, string x64str)
+        {
+            m_str = str;
+            m_x64Str = x64str;
+        }
+
+        /// <summary>
+        /// The architecture target determined, encrypted, string to utilize
+        /// </summary>
+        public string Active => Environment.Is64BitProcess ? m_x64Str : m_str;
+    }
+}


### PR DESCRIPTION
Adding obfuscated string, needed to support Any Cpu (which defaults to x86) and x64 architectures - both generate different obfuscated strings