### PR TITLE
[libs][ux] StackNav improvements

### DIFF
--- a/libs/AJut.UX.Wpf/Controls/StackNavDisplayElements/StackNavActiveContentPresenter.xaml
+++ b/libs/AJut.UX.Wpf/Controls/StackNavDisplayElements/StackNavActiveContentPresenter.xaml
@@ -10,7 +10,7 @@
         <Setter Property="CoverBackgroundBrush" Value="#C000"/>
         <Setter Property="Focusable" Value="True"/>
         <Setter Property="Background" Value="#01000000"/>
-        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="BorderThickness" Value="0"/>
         <Setter Property="BorderBrush" Value="Black"/>
         <Setter Property="Template">
             <Setter.Value>

--- a/libs/AJut.UX.Wpf/Controls/StackNavDisplayElements/StackNavActiveDrawerPresenter.xaml
+++ b/libs/AJut.UX.Wpf/Controls/StackNavDisplayElements/StackNavActiveDrawerPresenter.xaml
@@ -7,7 +7,7 @@
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <Style TargetType="{x:Type local:StackNavActiveDrawerPresenter}">
-        <Setter Property="BorderThickness" Value="1,1,0,1"/>
+        <Setter Property="BorderThickness" Value="0,0,1,0"/>
         <Setter Property="BorderBrush" Value="Black"/>
         <Setter Property="Visibility" Value="{Binding RelativeSource={RelativeSource Self}, Path=Navigator.IsDrawerOpen, Converter={ajconv:BooleanToVisibilityConverter FalseValue=Collapsed}}"/>
         <Setter Property="Template">

--- a/libs/AJut.UX.Wpf/Controls/StackNavDisplayElements/StackNavActiveHeaderPresenter.xaml
+++ b/libs/AJut.UX.Wpf/Controls/StackNavDisplayElements/StackNavActiveHeaderPresenter.xaml
@@ -8,7 +8,7 @@
                     xmlns:local="clr-namespace:AJut.UX.Controls">
 
     <Style TargetType="{x:Type local:StackNavActiveHeaderPresenter}">
-        <Setter Property="BorderThickness" Value="1,1,1,0"/>
+        <Setter Property="BorderThickness" Value="0,0,0,1"/>
         <Setter Property="BorderBrush" Value="Black"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="ShowDrawerButton" Value="True"/>

--- a/libs/AJut.UX.Wpf/Controls/WindowChromeButtonStrip.cs
+++ b/libs/AJut.UX.Wpf/Controls/WindowChromeButtonStrip.cs
@@ -7,10 +7,12 @@
     using System.Windows.Media;
     using AJut.UX.AttachedProperties;
     using DPUtils = AJut.UX.DPUtils<WindowChromeButtonStrip>;
+    using APUtils = AJut.UX.APUtils<WindowChromeButtonStrip>;
 
     [TemplatePart(Name = nameof(PART_ChromeCloseButton), Type = typeof(ButtonBase))]
     public class WindowChromeButtonStrip : Control
     {
+        private Window m_window;
         static WindowChromeButtonStrip ()
         {
             DefaultStyleKeyProperty.OverrideMetadata(typeof(WindowChromeButtonStrip), new FrameworkPropertyMetadata(typeof(WindowChromeButtonStrip)));
@@ -23,6 +25,25 @@
             this.CommandBindings.Add(new CommandBinding(SystemCommands.RestoreWindowCommand, OnRestoreWindow, OnCanRestoreWindow));
             this.CommandBindings.Add(new CommandBinding(WindowXTA.ToggleFullscreenCommand, OnToggleFullscreen, OnCanToggleFullscreen));
             this.CommandBindings.Add(new CommandBinding(SystemCommands.CloseWindowCommand, OnCloseWindow, OnCanCloseWindow));
+
+            this.Loaded += this.OnLoaded;
+        }
+
+
+        private static DependencyPropertyKey IsMouseOverClosePropertyKey = APUtils.RegisterReadOnly(GetIsMouseOverClose, SetIsMouseOverClose);
+        public static DependencyProperty IsMouseOverCloseProperty = IsMouseOverClosePropertyKey.DependencyProperty;
+        public static bool GetIsMouseOverClose (DependencyObject obj) => (bool)obj.GetValue(IsMouseOverCloseProperty);
+        internal static void SetIsMouseOverClose (DependencyObject obj, bool value) => obj.SetValue(IsMouseOverClosePropertyKey, value);
+
+
+        private void OnLoaded (object sender, RoutedEventArgs e)
+        {
+            if (m_window != null)
+            {
+                SetIsMouseOverClose(m_window, false);
+            }
+
+            m_window = Window.GetWindow(this);
         }
 
         private void OnCanMinimizeWindow (object sender, CanExecuteRoutedEventArgs e)
@@ -32,7 +53,7 @@
 
         private void OnMinimzeWindow (object sender, ExecutedRoutedEventArgs e)
         {
-            Window.GetWindow(this).WindowState = WindowState.Minimized;
+            m_window.WindowState = WindowState.Minimized;
         }
 
         private void OnCanMaximizeWindow (object sender, CanExecuteRoutedEventArgs e)
@@ -42,7 +63,7 @@
 
         private void OnMaximizeWindow (object sender, ExecutedRoutedEventArgs e)
         {
-            Window.GetWindow(this).WindowState = WindowState.Maximized;
+            m_window.WindowState = WindowState.Maximized;
         }
 
         private void OnCanRestoreWindow (object sender, CanExecuteRoutedEventArgs e)
@@ -52,7 +73,7 @@
 
         private void OnRestoreWindow (object sender, ExecutedRoutedEventArgs e)
         {
-            Window.GetWindow(this).WindowState = WindowState.Normal;
+            m_window.WindowState = WindowState.Normal;
         }
 
         private void OnCanToggleFullscreen (object sender, CanExecuteRoutedEventArgs e)
@@ -62,7 +83,7 @@
 
         private void OnToggleFullscreen (object sender, ExecutedRoutedEventArgs e)
         {
-            WindowXTA.ToggleIsFullscreen(Window.GetWindow(this));
+            WindowXTA.ToggleIsFullscreen(m_window);
         }
 
         private void OnCanCloseWindow (object sender, CanExecuteRoutedEventArgs e)
@@ -72,7 +93,7 @@
 
         private void OnCloseWindow (object sender, ExecutedRoutedEventArgs e)
         {
-            Window.GetWindow(this).Close();
+            m_window.Close();
         }
 
         public override void OnApplyTemplate ()
@@ -93,12 +114,12 @@
 
             void _OnChromeCloseButtonMouseEnter (object sender, MouseEventArgs e)
             {
-                this.IsMouseOverClose = true;
+                SetIsMouseOverClose(m_window, true);
             }
 
             void _OnChromeCloseButtonMouseLeave (object sender, MouseEventArgs e)
             {
-                this.IsMouseOverClose = false;
+                SetIsMouseOverClose(m_window, false);
             }
         }
 
@@ -278,14 +299,6 @@
         {
             get => (string)this.GetValue(CloseToolTipProperty);
             set => this.SetValue(CloseToolTipProperty, value);
-        }
-
-        private static readonly DependencyPropertyKey IsMouseOverClosePropertyKey = DPUtils.RegisterReadOnly(_ => _.IsMouseOverClose);
-        public static readonly DependencyProperty IsMouseOverCloseProperty = IsMouseOverClosePropertyKey.DependencyProperty;
-        public bool IsMouseOverClose
-        {
-            get => (bool)this.GetValue(IsMouseOverCloseProperty);
-            protected set => this.SetValue(IsMouseOverClosePropertyKey, value);
         }
     }
 }

--- a/sandbox/MainWindow.xaml
+++ b/sandbox/MainWindow.xaml
@@ -13,8 +13,21 @@
         ajutap:WindowXTA.FixMaximizeAsFullscreenIssue="True"
         ajutap:WindowXTA.MaximizedRootElementMargin="4,4"
         ajutap:WindowXTA.FullscreenRootElementMargin="4,3"
-        Background="#F9F9F9"
-        MinWidth="300" MinHeight="300">
+        Background="#F9F9F9" 
+        MinWidth="300" MinHeight="300" BorderThickness="2">
+    <Window.Style>
+        <Style TargetType="{x:Type Window}">
+            <Setter Property="BorderBrush" Value="#48C"/>
+            <Style.Triggers>
+                <Trigger Property="IsActive" Value="False">
+                    <Setter Property="BorderBrush" Value="#997B909E"/>
+                </Trigger>
+                <Trigger Property="ajut:WindowChromeButtonStrip.IsMouseOverClose" Value="True">
+                    <Setter Property="BorderBrush" Value="Red"/>
+                </Trigger>
+            </Style.Triggers>
+        </Style>
+    </Window.Style>
     <WindowChrome.WindowChrome>
         <WindowChrome CaptionHeight="40" ResizeBorderThickness="5"/>
     </WindowChrome.WindowChrome>
@@ -22,12 +35,16 @@
                           FixedDrawerWidth="260">
         <ajut:StackNavDisplay.Resources>
             <Style TargetType="{x:Type ajut:StackNavActiveHeaderPresenter}">
+                <Setter Property="BorderThickness" Value="0,0,0,1"/>
                 <Setter Property="Background" Value="#8CF"/>
                 <Setter Property="AdditionalRightSideDisplay">
                     <Setter.Value>
                         <ajut:WindowChromeButtonStrip Margin="2"/>
                     </Setter.Value>
                 </Setter>
+            </Style>
+            <Style TargetType="{x:Type ajut:StackNavBusyWaitOverlay}">
+                <Setter Property="Foreground" Value="Red"/>
             </Style>
             <Style TargetType="{x:Type ajut:StackNavActiveDrawerPresenter}">
                 <Setter Property="AdditionalBottomDisplay">


### PR DESCRIPTION
[libs][ux] Promoting IsMouseOverClose to an attached property to allow simpler binding path for border alteration as was intended, and exemplafying that in the sandbox. 

Altering back the stack nav defaults for borders to allow the window's border to be the default wrap around border instead of the stack nav elements, which makes a lot more sense and works best with the other change.