### PR TITLE
Small bugfixes & feature improvements

### DIFF
--- a/libs/AJut.Core/IO/FileHelpers.cs
+++ b/libs/AJut.Core/IO/FileHelpers.cs
@@ -90,15 +90,17 @@
         }
 
         /// <summary>
-        /// Gets the embedded resource name so that an embedded resource can be accessed by it's translated name.
+        /// Gets the embedded resource name that matches the relative path given
         /// </summary>
         /// <param name="relativePath">The relative path to the embedded resource</param>
         /// <param name="assembly">The assembly that the resource is in, or null if you want to use the executing assembly.</param>
-        /// <returns>The translated embedded resource name</returns>
+        /// <returns>The embedded resource name that matches the given relative path, or <c>null</c> if there is no match</returns>
         public static string GenerateEmbeddedResourceName (string relativePath, Assembly assembly = null)
         {
             assembly = assembly ?? Assembly.GetCallingAssembly();
-            return assembly.GetName().Name + "." + relativePath.Replace('/', '.').Replace('\\', '.').TrimStart('.'); ;
+
+            string transformedRelativePath = relativePath.Replace('/', '.').Replace('\\', '.').TrimStart('.');
+            return assembly.GetManifestResourceNames().FirstOrDefault(resource => resource.EndsWith(transformedRelativePath));
         }
 
         /// <summary>

--- a/libs/AJut.Core/Storage/Result.cs
+++ b/libs/AJut.Core/Storage/Result.cs
@@ -76,6 +76,11 @@
         }
 
         public static implicit operator bool (Result result) => !result.HasErrors;
+
+        public override string ToString ()
+        {
+            return this ? "<Successful Result>" : this.GetErrorReport();
+        }
     }
 
     /// <summary>
@@ -123,5 +128,10 @@
         public static implicit operator Result<T> (T successValue) => Result<T>.Success(successValue);
         public static implicit operator T (Result<T> successValue) => successValue.Value;
         public static implicit operator bool (Result<T> result) => !result.HasErrors;
+
+        public override string ToString ()
+        {
+            return this ? $"<Successful Result: {this.Value}>" : this.GetErrorReport();
+        }
     }
 }

--- a/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
@@ -298,6 +298,12 @@ namespace AJut.UX.Controls
             set => this.SetValue(ListBoxItemContainerStyleProperty, value);
         }
 
+        public static readonly DependencyProperty ShouldToggleExpandableItemExpansionOnDoubleClickProperty = DPUtils.Register(_ => _.ShouldToggleExpandableItemExpansionOnDoubleClick, true);
+        public bool ShouldToggleExpandableItemExpansionOnDoubleClick
+        {
+            get => (bool)this.GetValue(ShouldToggleExpandableItemExpansionOnDoubleClickProperty);
+            set => this.SetValue(ShouldToggleExpandableItemExpansionOnDoubleClickProperty, value);
+        }
 
         // ============================[Methods]================================
         public override void OnApplyTemplate ()
@@ -307,12 +313,14 @@ namespace AJut.UX.Controls
             if (this.PART_ListBoxDisplay != null)
             {
                 this.PART_ListBoxDisplay.SelectionChanged -= _OnSelectionChanged;
+                this.PART_ListBoxDisplay.MouseDoubleClick -= _OnMouseDoubleClick;
             }
 
             this.PART_ListBoxDisplay = (ListBox)this.GetTemplateChild(nameof(PART_ListBoxDisplay));
             this.PART_ListBoxDisplay.SelectionChanged += _OnSelectionChanged;
+            this.PART_ListBoxDisplay.MouseDoubleClick += _OnMouseDoubleClick;
 
-            void _OnSelectionChanged (object sender, SelectionChangedEventArgs _e)
+            void _OnSelectionChanged (object _sender, SelectionChangedEventArgs _e)
             {
                 // =====================================================
                 // = What happens when the ListBox's selection changes =
@@ -358,6 +366,13 @@ namespace AJut.UX.Controls
                 finally
                 {
                     m_blockingForSelectionChangeReentrancy = false;
+                }
+            }
+            void _OnMouseDoubleClick (object _sender, MouseButtonEventArgs _e)
+            {
+                if (this.ShouldToggleExpandableItemExpansionOnDoubleClick && this.PART_ListBoxDisplay.SelectedItem is Item item && item.IsExpandable)
+                {
+                    item.IsExpanded = !item.IsExpanded;
                 }
             }
         }

--- a/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
@@ -291,6 +291,14 @@ namespace AJut.UX.Controls
             set => this.SetValue(GlyphPaddingProperty, value);
         }
 
+        public static readonly DependencyProperty ListBoxItemContainerStyleProperty = DPUtils.Register(_ => _.ListBoxItemContainerStyle);
+        public Style ListBoxItemContainerStyle
+        {
+            get => (Style)this.GetValue(ListBoxItemContainerStyleProperty);
+            set => this.SetValue(ListBoxItemContainerStyleProperty, value);
+        }
+
+
         // ============================[Methods]================================
         public override void OnApplyTemplate ()
         {

--- a/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.xaml
+++ b/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.xaml
@@ -7,7 +7,7 @@
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
     <Style x:Key="AJut_Style_FlatTreeListBoxItem" TargetType="{x:Type ListBoxItem}">
-        <Setter Property="SnapsToDevicePixels" Value="true" />
+        <Setter Property="SnapsToDevicePixels" Value="True" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ListBoxItem}">
@@ -19,7 +19,7 @@
                                     <MultiDataTrigger>
                                         <MultiDataTrigger.Conditions>
                                             <Condition Binding="{Binding Path=IsSelectable}" Value="True" />
-                                            <Condition Binding="{ajut:TemplateBinding Path=IsSelected}" Value="True" />
+                                            <Condition Binding="{ajut:TemplateBinding Path=(Selector.IsSelectionActive)}" Value="True" />
                                         </MultiDataTrigger.Conditions>
                                         <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType=local:FlatTreeListControl}, Path=SelectionBrush}"/>
                                     </MultiDataTrigger>
@@ -43,13 +43,16 @@
 
     <Style TargetType="{x:Type local:FlatTreeListControl}">
         <Setter Property="BorderThickness" Value="0"/>
-        <Setter Property="BorderBrush" Value="Black"/>
+        <Setter Property="BorderBrush" Value="Gray"/>
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="ap:BorderXTA.CornerRadius" Value="3"/>
 
         <Setter Property="SelectionBrush" Value="#2196f3"/>
         <Setter Property="SelectionInactiveBrush" Value="#94B7D1"/>
         <Setter Property="Padding" Value="2,0,0,0"/>
+        
+        <Setter Property="ListBoxItemContainerStyle" Value="{StaticResource AJut_Style_FlatTreeListBoxItem}"/>
+        <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
         
         <Setter Property="GlyphBrush" Value="#222"/>
         <Setter Property="GlyphHighlightBrush" Value="Black"/>
@@ -60,95 +63,97 @@
         <Setter Property="CollapsedElementGlyph" Value="&#xE970;"/>
         <Setter Property="ExpandedElementGlyph" Value="&#xE96E;"/>
         <Setter Property="ExpandCollapseGlyphSize" Value="9"/>
-        
+
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
+
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:FlatTreeListControl}">
-                    <Border Background="{TemplateBinding Background}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            CornerRadius="{ajut:TemplateBinding Path=(ap:BorderXTA.CornerRadius)}">
-                        <ListBox x:Name="PART_ListBoxDisplay" ItemsSource="{ajut:TemplateBinding Path=Items}"
-                                 SelectionMode="{ajut:TemplateBinding Path=SelectionMode}"
-                                 VirtualizingPanel.IsVirtualizing="True"
-                                 ItemContainerStyle="{StaticResource AJut_Style_FlatTreeListBoxItem}"
-                                 Background="Transparent"
-                                 BorderThickness="0"
-                                 BorderBrush="Transparent">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="14"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Grid x:Name="Spacing" Grid.Column="0">
-                                            <Grid.Width>
-                                                <MultiBinding Converter="{conv:ArithmeticConverter Operation=Multiply}">
-                                                    <Binding Path="TreeDepth" Mode="OneWay"/>
-                                                    <Binding RelativeSource="{RelativeSource AncestorType=local:FlatTreeListControl}" Path="TabbingSize"/>
-                                                </MultiBinding>
-                                            </Grid.Width>
-                                        </Grid>
-                                        <ToggleButton x:Name="Expander" Grid.Column="1" IsChecked="{Binding Path=IsExpanded, Mode=TwoWay}" HorizontalAlignment="Center" VerticalAlignment="Center">
-                                            <ToggleButton.Style>
-                                                <Style TargetType="{x:Type ToggleButton}">
-                                                    <Setter Property="Background" Value="Transparent"/>
-                                                    <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphBrush}"/>
-                                                    <Setter Property="Content" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=CollapsedElementGlyph}" />
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding Path=IsExpandable}" Value="False">
-                                                            <Setter Property="Visibility" Value="Collapsed" />
-                                                        </DataTrigger>
-                                                        <DataTrigger Binding="{Binding Path=IsExpanded}" Value="True">
-                                                            <Setter Property="Content" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandedElementGlyph}" />
-                                                        </DataTrigger>
-                                                        <Trigger Property="IsMouseOver" Value="True">
-                                                            <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphHighlightBrush}"/>
-                                                            <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphBackgroundHighlightBrush}" />
-                                                        </Trigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </ToggleButton.Style>
-                                            <ToggleButton.Template>
-                                                <ControlTemplate TargetType="{x:Type ToggleButton}">
-                                                    <Border CornerRadius="2" Background="{TemplateBinding Background}">
-                                                        <ContentControl Content="{TemplateBinding Content}" VerticalAlignment="Center" Margin="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphPadding}">
-                                                            <ContentControl.Resources>
-                                                                <DataTemplate DataType="{x:Type PathGeometry}">
-                                                                    <Path Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandCollapseGlyphSize}"
-                                                                          Height="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandCollapseGlyphSize}"
-                                                                          Stroke="{Binding RelativeSource={RelativeSource AncestorType={x:Type ToggleButton}}, Path=Foreground}" 
-                                                                          Fill="{Binding RelativeSource={RelativeSource AncestorType={x:Type ToggleButton}}, Path=Foreground}"
-                                                                          Data="{Binding .}"
-                                                                          VerticalAlignment="Center"
-                                                                          HorizontalAlignment="Center"
-                                                                          Stretch="Uniform"/>
-                                                                </DataTemplate>
-                                                                <DataTemplate DataType="{x:Type sys:String}">
-                                                                    <TextBlock Text="{Binding .}"
-                                                                               Foreground="{Binding RelativeSource={RelativeSource AncestorType=ToggleButton}, Path=Foreground}"
-                                                                               FontSize="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandCollapseGlyphSize}"
-                                                                               FontFamily="Segoe MDL2 Assets"
-                                                                               VerticalAlignment="Center"
-                                                                               HorizontalAlignment="Center"/>
-                                                                </DataTemplate>
-                                                            </ContentControl.Resources>
-                                                        </ContentControl>
-                                                    </Border>
-                                                </ControlTemplate>
-                                            </ToggleButton.Template>
-                                        </ToggleButton>
-                                        <ContentPresenter x:Name="Content" Grid.Column="2" Content="{Binding Source}" HorizontalAlignment="Stretch"
-                                                          Margin="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=Padding}"
-                                                          ContentTemplate="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ItemTemplate}"
-                                                          ContentTemplateSelector="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ItemTemplateSelector}"/>
+                    <ListBox x:Name="PART_ListBoxDisplay" ItemsSource="{ajut:TemplateBinding Path=Items}"
+                             SelectionMode="{ajut:TemplateBinding Path=SelectionMode}"
+                             VirtualizingPanel.IsVirtualizing="True"
+                             ItemContainerStyle="{TemplateBinding ListBoxItemContainerStyle}"
+                             ScrollViewer.HorizontalScrollBarVisibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=(ScrollViewer.HorizontalScrollBarVisibility)}"
+                             ScrollViewer.VerticalScrollBarVisibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=(ScrollViewer.VerticalScrollBarVisibility)}"
+                             Background="{TemplateBinding Background}"
+                             BorderThickness="{TemplateBinding BorderThickness}"
+                             BorderBrush="{TemplateBinding BorderBrush}"
+                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                             ap:BorderXTA.CornerRadius="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=(ap:BorderXTA.CornerRadius)}">
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto"/>
+                                        <ColumnDefinition Width="14"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <Grid x:Name="Spacing" Grid.Column="0">
+                                        <Grid.Width>
+                                            <MultiBinding Converter="{conv:ArithmeticConverter Operation=Multiply}">
+                                                <Binding Path="TreeDepth" Mode="OneWay"/>
+                                                <Binding RelativeSource="{RelativeSource AncestorType=local:FlatTreeListControl}" Path="TabbingSize"/>
+                                            </MultiBinding>
+                                        </Grid.Width>
                                     </Grid>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                    </Border>
+                                    <ToggleButton x:Name="Expander" Grid.Column="1" IsChecked="{Binding Path=IsExpanded, Mode=TwoWay}" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <ToggleButton.Style>
+                                            <Style TargetType="{x:Type ToggleButton}">
+                                                <Setter Property="Background" Value="Transparent"/>
+                                                <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphBrush}"/>
+                                                <Setter Property="Content" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=CollapsedElementGlyph}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Path=IsExpandable}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                    <DataTrigger Binding="{Binding Path=IsExpanded}" Value="True">
+                                                        <Setter Property="Content" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandedElementGlyph}" />
+                                                    </DataTrigger>
+                                                    <Trigger Property="IsMouseOver" Value="True">
+                                                        <Setter Property="Foreground" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphHighlightBrush}"/>
+                                                        <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphBackgroundHighlightBrush}" />
+                                                    </Trigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ToggleButton.Style>
+                                        <ToggleButton.Template>
+                                            <ControlTemplate TargetType="{x:Type ToggleButton}">
+                                                <Border CornerRadius="2" Background="{TemplateBinding Background}">
+                                                    <ContentControl Content="{TemplateBinding Content}" VerticalAlignment="Center" Margin="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=GlyphPadding}">
+                                                        <ContentControl.Resources>
+                                                            <DataTemplate DataType="{x:Type PathGeometry}">
+                                                                <Path Width="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandCollapseGlyphSize}"
+                                                                        Height="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandCollapseGlyphSize}"
+                                                                        Stroke="{Binding RelativeSource={RelativeSource AncestorType={x:Type ToggleButton}}, Path=Foreground}" 
+                                                                        Fill="{Binding RelativeSource={RelativeSource AncestorType={x:Type ToggleButton}}, Path=Foreground}"
+                                                                        Data="{Binding .}"
+                                                                        VerticalAlignment="Center"
+                                                                        HorizontalAlignment="Center"
+                                                                        Stretch="Uniform"/>
+                                                            </DataTemplate>
+                                                            <DataTemplate DataType="{x:Type sys:String}">
+                                                                <TextBlock Text="{Binding .}"
+                                                                            Foreground="{Binding RelativeSource={RelativeSource AncestorType=ToggleButton}, Path=Foreground}"
+                                                                            FontSize="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ExpandCollapseGlyphSize}"
+                                                                            FontFamily="Segoe MDL2 Assets"
+                                                                            VerticalAlignment="Center"
+                                                                            HorizontalAlignment="Center"/>
+                                                            </DataTemplate>
+                                                        </ContentControl.Resources>
+                                                    </ContentControl>
+                                                </Border>
+                                            </ControlTemplate>
+                                        </ToggleButton.Template>
+                                    </ToggleButton>
+                                    <ContentPresenter x:Name="Content" Grid.Column="2" Content="{Binding Source}" HorizontalAlignment="Stretch"
+                                                        Margin="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=Padding}"
+                                                        ContentTemplate="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ItemTemplate}"
+                                                        ContentTemplateSelector="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:FlatTreeListControl}}, Path=ItemTemplateSelector}"/>
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/libs/AJut.UX.Wpf/Controls/PropertyGrid.xaml
+++ b/libs/AJut.UX.Wpf/Controls/PropertyGrid.xaml
@@ -16,33 +16,37 @@
                 </Style>
             </Setter.Value>
         </Setter>
+        <Setter Property="BorderBrush" Value="Gray"/>
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto"/>
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Auto"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type local:PropertyGrid}">
-                    <Border Background="{TemplateBinding Background}" 
-                            BorderThickness="{TemplateBinding BorderThickness}" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            CornerRadius="{ajut:TemplateBinding Path=(ap:BorderXTA.CornerRadius)}"
-                            Grid.IsSharedSizeScope="True">
-                        <local:FlatTreeListControl RootItemsSource="{TemplateBinding Items}">
-                            <local:FlatTreeListControl.ItemTemplate>
-                                <DataTemplate DataType="{x:Type prop:PropertyEditTarget}">
-                                    <Grid Margin="3">
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto" SharedSizeGroup="Header"/>
-                                            <ColumnDefinition Width="*"/>
-                                        </Grid.ColumnDefinitions>
-                                        <TextBlock Text="{Binding Path=DisplayName, Mode=OneWay}" VerticalAlignment="Center" Margin="0,0,7,0"
-                                                   Style="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=TextLabelStyle}"/>
-                                        <ContentPresenter Grid.Column="1" VerticalAlignment="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=VerticalContentAlignment}" HorizontalAlignment="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=HorizontalContentAlignment}"
-                                                          ContentTemplateSelector="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=ItemTemplateSelector}"
-                                                          Content="{Binding}"
-                                                          ap:Edit.IsReadOnly="{Binding Path=IsReadOnly, Mode=OneWay}"/>
-                                    </Grid>
-                                </DataTemplate>
-                            </local:FlatTreeListControl.ItemTemplate>
-                        </local:FlatTreeListControl>
-                    </Border>
+                    <local:FlatTreeListControl RootItemsSource="{TemplateBinding Items}"
+                                               Background="{TemplateBinding Background}" 
+                                               BorderThickness="{TemplateBinding BorderThickness}" 
+                                               BorderBrush="{TemplateBinding BorderBrush}" 
+                                               ap:BorderXTA.CornerRadius="{ajut:TemplateBinding Path=(ap:BorderXTA.CornerRadius)}"
+                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               ScrollViewer.HorizontalScrollBarVisibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=(ScrollViewer.HorizontalScrollBarVisibility)}"
+                                               ScrollViewer.VerticalScrollBarVisibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=(ScrollViewer.VerticalScrollBarVisibility)}">
+                        <local:FlatTreeListControl.ItemTemplate>
+                            <DataTemplate DataType="{x:Type prop:PropertyEditTarget}">
+                                <Grid Margin="3">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" SharedSizeGroup="Header"/>
+                                        <ColumnDefinition Width="*"/>
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Text="{Binding Path=DisplayName, Mode=OneWay}" VerticalAlignment="Center" Margin="0,0,7,0"
+                                                Style="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=TextLabelStyle}"/>
+                                    <ContentPresenter Grid.Column="1" VerticalAlignment="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=VerticalContentAlignment}" HorizontalAlignment="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=HorizontalContentAlignment}"
+                                                        ContentTemplateSelector="{Binding RelativeSource={RelativeSource AncestorType={x:Type local:PropertyGrid}}, Path=ItemTemplateSelector}"
+                                                        Content="{Binding}"
+                                                        ap:Edit.IsReadOnly="{Binding Path=IsReadOnly, Mode=OneWay}"/>
+                                </Grid>
+                            </DataTemplate>
+                        </local:FlatTreeListControl.ItemTemplate>
+                    </local:FlatTreeListControl>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>

--- a/libs/AJut.UX.Wpf/Resources/DarkThemeColorsBase.xaml
+++ b/libs/AJut.UX.Wpf/Resources/DarkThemeColorsBase.xaml
@@ -47,7 +47,9 @@
     <SolidColorBrush x:Key="AJut_Brush_ListBackground" Color="#36393A" />
     <SolidColorBrush x:Key="AJut_Brush_ListBorder" Color="#000" />
     <SolidColorBrush x:Key="AJut_Brush_ListSelection" Color="#0864A5" />
+    <SolidColorBrush x:Key="AJut_Brush_ListSelectionBackground" Color="#19119CFF" />
     <SolidColorBrush x:Key="AJut_Brush_TreeSelection" Color="#0864A5" />
+    <SolidColorBrush x:Key="AJut_Brush_ListItemHover" Color="{DynamicResource AJut_Color_PrimaryHighlight}" />
 
     <Color x:Key="AJut_Color_BorderCommon">#555</Color>
     <Color x:Key="AJut_Color_BorderCommonTransparent">#0555</Color>

--- a/libs/AJut.UX.Wpf/Resources/LightThemeColorsBase.xaml
+++ b/libs/AJut.UX.Wpf/Resources/LightThemeColorsBase.xaml
@@ -47,8 +47,10 @@
     <SolidColorBrush x:Key="AJut_Brush_ListBackground" Color="#EAEAEA" />
     <SolidColorBrush x:Key="AJut_Brush_ListBorder" Color="#555" />
     <SolidColorBrush x:Key="AJut_Brush_ListSelection" Color="{DynamicResource AJut_Color_PrimaryHighlight}" />
+    <SolidColorBrush x:Key="AJut_Brush_ListSelectionBackground" Color="#190284FF" />
     <SolidColorBrush x:Key="AJut_Brush_TreeSelection" Color="{DynamicResource AJut_Color_PrimaryHighlight}" />
-
+    <SolidColorBrush x:Key="AJut_Brush_ListItemHover" Color="{DynamicResource AJut_Color_PrimaryHighlightBright}" />
+    
     <Color x:Key="AJut_Color_BorderCommon">#8A8A8A</Color>
     <Color x:Key="AJut_Color_BorderCommonTransparent">#008A8A8A</Color>
     <SolidColorBrush x:Key="AJut_Brush_BorderCommon" Color="{DynamicResource AJut_Color_BorderCommon}"/>

--- a/libs/AJut.UX.Wpf/Resources/ThemedControlStylesBase.xaml
+++ b/libs/AJut.UX.Wpf/Resources/ThemedControlStylesBase.xaml
@@ -9,13 +9,14 @@
                     xmlns:sys="clr-namespace:System;assembly=mscorlib"
                     xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework">
 
+
     <FontFamily x:Key="AJut_Font_Default">Segoe UI</FontFamily>
 
     <FontFamily x:Key="AJut_Font_SymbolGlyphText">Segoe MDL2 Assets</FontFamily>
     <sys:String x:Key="AJut_Symbol_Check">&#xE73E;</sys:String>
     <sys:String x:Key="AJut_Symbol_Dash">&#xE9AE;</sys:String>
     <sys:String x:Key="AJut_Symbol_NeedsEdit">&#xEB7E;</sys:String>
-    
+
     <sys:String x:Key="AJut_Symbol_UpChevron"   >&#xE70E;</sys:String>
     <sys:String x:Key="AJut_Symbol_DownChevron" >&#xE70D;</sys:String>
     <sys:String x:Key="AJut_Symbol_LeftChevron" >&#xE76B;</sys:String>
@@ -59,13 +60,13 @@
         <Setter Property="LabelPadding" Value="4"/>
         <Setter Property="FontFamily" Value="Consolas"/>
         <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_SymbolForegroundHighlight}"/>
-                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
-            </Trigger>
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_SymbolForegroundHighlight}"/>
                 <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_SymbolForegroundHighlight}"/>
+                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlightBrightBright}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -99,9 +100,68 @@
         <Setter Property="GlyphHighlightBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}"/>
         <Setter Property="Background" Value="{DynamicResource AJut_Brush_ListBackground}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_ListBorder}"/>
+        <Setter Property="ListBoxItemContainerStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type ListBoxItem}">
+                    <Setter Property="SnapsToDevicePixels" Value="True" />
+                    <Setter Property="BorderBrush" Value="Transparent"/>
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                                <Border Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBoxItem}}, Path=(ajut_ap:BorderXTA.CornerRadius)}"
+                                        IsHitTestVisible="True">
+                                    <DockPanel>
+                                        <Grid DockPanel.Dock="Left" Background="{TemplateBinding BorderBrush}" Width="10"
+                                              Visibility="{Binding Path=IsSelected, Converter={ajut_conv:BooleanToVisibilityConverter TrueValue=Visible, FalseValue=Hidden}}"/>
+                                        <ContentPresenter Content="{Binding}" 
+                                                          ContentTemplate="{Binding RelativeSource={RelativeSource AncestorType=ListBox}, Path=ItemTemplate}" 
+                                                          ContentTemplateSelector="{Binding RelativeSource={RelativeSource AncestorType=ListBox}, Path=ItemTemplateSelector}" 
+                                                          Margin="{TemplateBinding Padding}"
+                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}" 
+                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"/>
+                                    </DockPanel>
+                                </Border>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                    <Style.Triggers>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelectable}" Value="True" />
+                                <Condition Binding="{Binding Path=IsSelected}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Selector.IsSelectionActive)}" Value="True" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type ajut_ctrls:FlatTreeListControl}}, Path=SelectionBrush}"/>
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelectable}" Value="True" />
+                                <Condition Binding="{Binding Path=IsSelected}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(Selector.IsSelectionActive)}" Value="False" />
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="BorderBrush" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type ajut_ctrls:FlatTreeListControl}}, Path=SelectionInactiveBrush}"/>
+                        </MultiDataTrigger>
+                        <MultiDataTrigger>
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding Path=IsSelectable}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="True" />
+                                <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(ajut_themext:AJutThemedListControlXTA.ListItemsShowHover)}"  Value="True"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_ListItemHover}"/>
+                            <Setter Property="Background" Value="{DynamicResource AJut_Brush_ListSelectionBackground}"/>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="{x:Type ajut_ctrls:PropertyGrid}">
+        <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_ListBorder}" />
+        <Setter Property="Background" Value="{DynamicResource AJut_Brush_ListBackground}"/>
         <Setter Property="TextLabelStyle">
             <Setter.Value>
                 <Style TargetType="{x:Type TextBlock}" BasedOn="{StaticResource AJut_Style_DefaultTextBlock}">
@@ -110,6 +170,11 @@
                 </Style>
             </Setter.Value>
         </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource AJut_Double_StandardDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="{x:Type ajut_ctrls:ColorEditIngressControl}">
@@ -374,7 +439,6 @@
 
     <Style TargetType="{x:Type ToggleButton}" BasedOn="{StaticResource AJut_Style_ToggleButton}" />
 
-
     <Style x:Key="AJut_Style_MessageBoxButton" TargetType="{x:Type Button}" BasedOn="{StaticResource AJut_Style_ButtonBase}">
         <Setter Property="TextElement.FontSize" Value="14"/>
         <Setter Property="Padding" Value="5,2"/>
@@ -396,7 +460,8 @@
                     <Border Background="{TemplateBinding Background}" BorderBrush="{DynamicResource AJut_Brush_BorderCommon}">
                         <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}">
                             <DockPanel>
-                                <Grid DockPanel.Dock="Left" Background="{TemplateBinding BorderBrush}" Width="10"/>
+                                <Grid DockPanel.Dock="Left" Background="{DynamicResource AJut_Brush_ListSelection}" Width="10"
+                                      Visibility="{Binding Path=IsSelected, RelativeSource={RelativeSource AncestorType=ListBoxItem}, Converter={ajut_conv:BooleanToVisibilityConverter TrueValue=Visible, FalseValue=Hidden}}"/>
                                 <ContentPresenter Content="{Binding}" 
                                                   ContentTemplate="{Binding RelativeSource={RelativeSource AncestorType=ListBox}, Path=ItemTemplate}" 
                                                   ContentTemplateSelector="{Binding RelativeSource={RelativeSource AncestorType=ListBox}, Path=ItemTemplateSelector}" 
@@ -413,11 +478,48 @@
             <Trigger Property="IsSelected" Value="True">
                 <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_ListSelection}"/>
             </Trigger>
+            <MultiDataTrigger>
+                <MultiDataTrigger.Conditions>
+                    <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=IsMouseOver}" Value="True"/>
+                    <Condition Binding="{Binding RelativeSource={RelativeSource Self}, Path=(ajut_themext:AJutThemedListControlXTA.ListItemsShowHover)}"  Value="True"/>
+                </MultiDataTrigger.Conditions>
+                <MultiDataTrigger.Setters>
+                    <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_ListItemHover}"/>
+                    <Setter Property="Background" Value="{DynamicResource AJut_Brush_ListSelectionBackground}"/>
+                </MultiDataTrigger.Setters>
+            </MultiDataTrigger>
         </Style.Triggers>
     </Style>
     <Style TargetType="{x:Type ListBox}">
         <Setter Property="Background" Value="{DynamicResource AJut_Brush_ListBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_ListBorder}" />
+        <Setter Property="ScrollViewer.CanContentScroll" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ListBox}">
+                    <Border Background="{TemplateBinding Background}" CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}"
+                            BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}">
+                        <ScrollViewer Focusable="False" Template="{DynamicResource AJut_ControlTemplate_ScrollViewer}"
+                                      HorizontalScrollBarVisibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=(ScrollViewer.HorizontalScrollBarVisibility)}"
+                                      VerticalScrollBarVisibility="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=(ScrollViewer.VerticalScrollBarVisibility)}"
+                                      CanContentScroll="{Binding RelativeSource={RelativeSource AncestorType={x:Type ListBox}}, Path=(ScrollViewer.CanContentScroll)}"
+                                      ajut_ap:BorderXTA.CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}">
+                            <StackPanel Margin="{TemplateBinding Padding}" IsItemsHost="True" />
+                        </ScrollViewer>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsGrouping" Value="True">
+                            <Setter Property="ScrollViewer.CanContentScroll" Value="False" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style.Triggers>
+            <Trigger Property="IsEnabled" Value="False">
+                <Setter Property="Opacity" Value="{DynamicResource AJut_Double_StandardDisabledOpacity}"/>
+            </Trigger>
+        </Style.Triggers>
     </Style>
 
     <Style TargetType="{x:Type TabControl}">
@@ -462,7 +564,7 @@
             </Setter.Value>
         </Setter>
     </Style>
-    
+
     <Style TargetType="{x:Type TabItem}">
         <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=Background, Mode=OneWay}" />
         <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_NormalText}" />
@@ -515,11 +617,11 @@
                                 </Grid>
                                 <Border x:Name="SelectionIndicator" BorderBrush="{DynamicResource AJut_Brush_PrimaryHighlight}" Margin="2">
                                     <ContentPresenter x:Name="AJutTabItemThemed_HeaderPresenter" Content="{TemplateBinding Header}" 
-                                              ContentTemplate="{TemplateBinding HeaderTemplate}" 
-                                              ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" 
-                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                              Margin="{TemplateBinding Padding}">
+                                                      ContentTemplate="{TemplateBinding HeaderTemplate}" 
+                                                      ContentTemplateSelector="{TemplateBinding HeaderTemplateSelector}" 
+                                                      HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                      VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                      Margin="{TemplateBinding Padding}">
                                         <ContentPresenter.Resources>
                                             <Style TargetType="{x:Type TextBlock}">
                                                 <Setter Property="Foreground" Value="{Binding Path=Foreground, RelativeSource={RelativeSource AncestorType={x:Type TabItem}}}"/>
@@ -590,20 +692,6 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
-        <!--<Style.Triggers>
-            <Trigger Property="IsSelected" Value="True">
-                <Setter Property="Background" Value="{Binding RelativeSource={RelativeSource AncestorType=TabControl}, Path=Background}" />
-            </Trigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=TabStripPlacement}" Value="Left">
-                <Setter Property="BorderThickness" Value="1,1,0,1"/>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=TabStripPlacement}" Value="Right">
-                <Setter Property="BorderThickness" Value="0,1,1,1"/>
-            </DataTrigger>
-            <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type TabControl}}, Path=TabStripPlacement}" Value="Bottom">
-                <Setter Property="BorderThickness" Value="1,0,1,1"/>
-            </DataTrigger>
-        </Style.Triggers>-->
     </Style>
 
     <Style TargetType="{x:Type TextBox}">
@@ -622,12 +710,12 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
-            </Trigger>
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_InteractiveText}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlightBright}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -649,12 +737,13 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
-            </Trigger>
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_InteractiveText}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
+                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlightBright}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -773,12 +862,12 @@
             </Setter.Value>
         </Setter>
         <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
-            </Trigger>
             <Trigger Property="IsKeyboardFocusWithin" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_InteractiveText}" />
                 <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlight}" />
+            </Trigger>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_PrimaryHighlightBright}" />
             </Trigger>
         </Style.Triggers>
     </Style>
@@ -1150,59 +1239,55 @@
         </Setter>
     </Style>
 
+    <ControlTemplate x:Key="AJut_ControlTemplate_ScrollViewer" TargetType="{x:Type ScrollViewer}">
+        <Border CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}" 
+                BorderBrush="{TemplateBinding BorderBrush}"
+                BorderThickness="{TemplateBinding BorderThickness}"
+                Background="{TemplateBinding Background}">
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="Auto"/>
+                </Grid.ColumnDefinitions>
+
+                <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
+                                        Margin="{TemplateBinding Padding}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        CanContentScroll="{TemplateBinding CanContentScroll}"/>
+
+                <ScrollBar x:Name="PART_VerticalScrollBar" Width="18"
+                           IsTabStop="False"
+                           Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
+                           Grid.Column="1" Grid.Row="0" Orientation="Vertical"
+                           ViewportSize="{TemplateBinding ViewportHeight}"
+                           Maximum="{TemplateBinding ScrollableHeight}"
+                           Minimum="0"
+                           Value="{TemplateBinding VerticalOffset}"/>
+
+                <ScrollBar x:Name="PART_HorizontalScrollBar" Height="18"
+                           IsTabStop="False"
+                           Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
+                           Grid.Column="0" Grid.Row="1" Orientation="Horizontal"
+                           ViewportSize="{TemplateBinding ViewportWidth}"
+                           Maximum="{TemplateBinding ScrollableWidth}"
+                           Minimum="0"
+                           Value="{TemplateBinding HorizontalOffset}"/>
+            </Grid>
+        </Border>
+    </ControlTemplate>
+
     <Style TargetType="{x:Type ScrollViewer}">
         <Setter Property="Background" Value="Transparent"/>
         <Setter Property="HorizontalScrollBarVisibility" Value="Auto"/>
         <Setter Property="VerticalScrollBarVisibility" Value="Auto"/>
         <Setter Property="ajut_ap:BorderXTA.CornerRadius" Value="2" />
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="{x:Type ScrollViewer}">
-                    <Border CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}" 
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}">
-                        <Grid Background="{TemplateBinding Background}">
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*"/>
-                                <RowDefinition Height="Auto"/>
-                            </Grid.RowDefinitions>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*"/>
-                                <ColumnDefinition Width="Auto"/>
-                            </Grid.ColumnDefinitions>
-
-                            <ScrollContentPresenter x:Name="PART_ScrollContentPresenter"
-                                        Margin="{TemplateBinding Padding}"
-                                        ContentTemplate="{TemplateBinding ContentTemplate}"
-                                        CanContentScroll="{TemplateBinding CanContentScroll}"/>
-
-                            <ScrollBar x:Name="PART_VerticalScrollBar" Width="18"
-                                     IsTabStop="False"
-                                     Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}"
-                                     Grid.Column="1" Grid.Row="0" Orientation="Vertical"
-                                     ViewportSize="{TemplateBinding ViewportHeight}"
-                                     Maximum="{TemplateBinding ScrollableHeight}"
-                                     Minimum="0"
-                                     Value="{TemplateBinding VerticalOffset}"
-                                     Margin="0,-1,-1,-1"/>
-
-                            <ScrollBar x:Name="PART_HorizontalScrollBar" Height="18"
-                                     IsTabStop="False"
-                                     Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}"
-                                     Grid.Column="0" Grid.Row="1" Orientation="Horizontal"
-                                     ViewportSize="{TemplateBinding ViewportWidth}"
-                                     Maximum="{TemplateBinding ScrollableWidth}"
-                                     Minimum="0"
-                                     Value="{TemplateBinding HorizontalOffset}"
-                                     Margin="-1,0,-1,-1"/>
-
-                        </Grid>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
+        <Setter Property="Template" Value="{DynamicResource AJut_ControlTemplate_ScrollViewer}"/>
     </Style>
-    
+
     <Style TargetType="{x:Type ScrollBar}">
         <Setter Property="Background" Value="{DynamicResource AJut_Brush_BorderCommon}"/>
         <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_BorderCommon}"/>
@@ -1212,7 +1297,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ScrollBar}">
-                            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0"
+                            <Border BorderBrush="{TemplateBinding BorderBrush}" UseLayoutRounding="True" SnapsToDevicePixels="True"
                                     Opacity="{ajut:TemplateBinding Path=IsEnabled, Converter={ajut_conv:BooleanToValueConverter TrueValue=1.0, FalseValue=0.5}}">
                                 <Grid>
                                     <Grid.Resources>
@@ -1221,8 +1306,8 @@
                                                 <Setter.Value>
                                                     <ControlTemplate TargetType="{x:Type RepeatButton}">
                                                         <Border BorderBrush="{TemplateBinding BorderBrush}"
-                                                        Background="{TemplateBinding Background}"
-                                                        BorderThickness="{TemplateBinding BorderThickness}"/>
+                                                                Background="{TemplateBinding Background}"
+                                                                BorderThickness="{TemplateBinding BorderThickness}"/>
                                                     </ControlTemplate>
                                                 </Setter.Value>
                                             </Setter>
@@ -1234,7 +1319,7 @@
                                         <RowDefinition Height="Auto"/>
                                     </Grid.RowDefinitions>
 
-                                    <Grid Grid.RowSpan="3" Margin="1,18" Opacity="0.5">
+                                    <Grid Grid.RowSpan="3" Margin="1.7,17,1.7,17" Opacity="0.5">
                                         <Grid.Background>
                                             <LinearGradientBrush StartPoint="0,5" EndPoint="-4,8" MappingMode="Absolute" SpreadMethod="Reflect">
                                                 <GradientStop Offset="0.00" Color="{DynamicResource AJut_Color_BorderCommon}" />
@@ -1247,7 +1332,7 @@
                                         </Grid.Background>
                                     </Grid>
 
-                                    <Grid Grid.Row="0" Margin="-1,0" Width="17" Height="17">
+                                    <Grid Grid.Row="0" Width="17" Height="17">
                                         <RepeatButton x:Name="PART_LineUpButton"
                                                       Command="{Binding Source={x:Static ScrollBar.LineUpCommand}}"
                                                       Style="{DynamicResource AJut_Style_ButtonBase}"/>
@@ -1266,23 +1351,23 @@
                                                           Background="Transparent" BorderBrush="Transparent"/>
                                         </Track.DecreaseRepeatButton>
                                         <Track.Thumb>
-                                            <Thumb Margin="-1,0">
+                                            <Thumb Margin="0.9,-1,0,-1.5">
                                                 <Thumb.Style>
                                                     <Style TargetType="{x:Type Thumb}">
                                                         <Setter Property="Background" Value="{DynamicResource AJut_Brush_ControlBackground}"/>
                                                         <Setter Property="Template">
                                                             <Setter.Value>
                                                                 <ControlTemplate TargetType="{x:Type Thumb}">
-                                                                    <Border BorderThickness="1,1,0,0" BorderBrush="#2FFF">
-                                                                        <Border BorderThickness="0,0,1,1" BorderBrush="#6000"
-                                                                                Background="{TemplateBinding Background}"/>
-                                                                    </Border>
+                                                                    <Border BorderThickness="1,1,0,0" BorderBrush="{DynamicResource AJut_Brush_BorderCommon}"
+                                                                            Background="{TemplateBinding Background}"/>
                                                                 </ControlTemplate>
                                                             </Setter.Value>
                                                         </Setter>
                                                         <Style.Triggers>
                                                             <Trigger Property="IsMouseOver" Value="True">
                                                                 <Setter Property="Background" Value="{DynamicResource AJut_Brush_ControlBackgroundHover}"/>
+                                                                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_BorderCommonHover}"/>
+                                                                <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_HighlightText}" />
                                                             </Trigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -1291,7 +1376,7 @@
                                         </Track.Thumb>
                                     </Track>
 
-                                    <Grid Grid.Row="2" Margin="-1,0" Width="17" Height="17">
+                                    <Grid Grid.Row="2" Width="17" Height="17">
                                         <RepeatButton x:Name="PART_LineDownButton"
                                                       Command="{Binding Source={x:Static ScrollBar.LineDownCommand}}"
                                                       Style="{DynamicResource AJut_Style_ButtonBase}"/>
@@ -1310,7 +1395,7 @@
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="{x:Type ScrollBar}">
-                            <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1,0"
+                            <Border BorderBrush="{TemplateBinding BorderBrush}"  UseLayoutRounding="True" SnapsToDevicePixels="True"
                                     Opacity="{ajut:TemplateBinding Path=IsEnabled, Converter={ajut_conv:BooleanToValueConverter TrueValue=1.0, FalseValue=0.5}}">
                                 <Border.Style>
                                     <Style TargetType="{x:Type Border}">
@@ -1328,8 +1413,8 @@
                                                 <Setter.Value>
                                                     <ControlTemplate TargetType="{x:Type RepeatButton}">
                                                         <Border BorderBrush="{TemplateBinding BorderBrush}"
-                                                        Background="{TemplateBinding Background}"
-                                                        BorderThickness="{TemplateBinding BorderThickness}"/>
+                                                                Background="{TemplateBinding Background}"
+                                                                BorderThickness="{TemplateBinding BorderThickness}"/>
                                                     </ControlTemplate>
                                                 </Setter.Value>
                                             </Setter>
@@ -1340,7 +1425,7 @@
                                         <ColumnDefinition Width="{ajut:TemplateBinding Path=ViewportSize, Mode=TwoWay, Converter={ajut_conv:PercentageToGridLengthConverter}}"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <Grid Grid.ColumnSpan="3" Margin="18,1" Opacity="0.5">
+                                    <Grid Grid.ColumnSpan="3" Margin="17,1.7,17,1.7" Opacity="0.5">
                                         <Grid.Background>
                                             <LinearGradientBrush StartPoint="5,0" EndPoint="8,-4" MappingMode="Absolute" SpreadMethod="Reflect">
                                                 <GradientStop Offset="0.00" Color="{DynamicResource AJut_Color_BorderCommon}" />
@@ -1352,7 +1437,7 @@
                                             </LinearGradientBrush>
                                         </Grid.Background>
                                     </Grid>
-                                    <Grid Grid.Column="0" Margin="0,-1" Width="17" Height="17">
+                                    <Grid Grid.Column="0" Width="17" Height="17">
                                         <RepeatButton x:Name="PART_LineLeftButton"
                                                       Command="{Binding Source={x:Static ScrollBar.LineLeftCommand}}"
                                                       Style="{DynamicResource AJut_Style_ButtonBase}"/>
@@ -1371,23 +1456,23 @@
                                                           Background="Transparent" BorderBrush="Transparent"/>
                                         </Track.DecreaseRepeatButton>
                                         <Track.Thumb>
-                                            <Thumb Margin="-1,0">
+                                            <Thumb Margin="-1,0.9,-1,0">
                                                 <Thumb.Style>
                                                     <Style TargetType="{x:Type Thumb}">
                                                         <Setter Property="Background" Value="{DynamicResource AJut_Brush_ControlBackground}"/>
                                                         <Setter Property="Template">
                                                             <Setter.Value>
                                                                 <ControlTemplate TargetType="{x:Type Thumb}">
-                                                                    <Border BorderThickness="1,1,0,0" BorderBrush="#2FFF">
-                                                                        <Border BorderThickness="0,0,1,1" BorderBrush="#6000"
-                                                                                Background="{TemplateBinding Background}"/>
-                                                                    </Border>
+                                                                    <Border BorderThickness="1" BorderBrush="{DynamicResource AJut_Brush_BorderCommon}"
+                                                                            Background="{TemplateBinding Background}"/>
                                                                 </ControlTemplate>
                                                             </Setter.Value>
                                                         </Setter>
                                                         <Style.Triggers>
                                                             <Trigger Property="IsMouseOver" Value="True">
                                                                 <Setter Property="Background" Value="{DynamicResource AJut_Brush_ControlBackgroundHover}"/>
+                                                                <Setter Property="BorderBrush" Value="{DynamicResource AJut_Brush_BorderCommonHover}"/>
+                                                                <Setter Property="Foreground" Value="{DynamicResource AJut_Brush_HighlightText}" />
                                                             </Trigger>
                                                         </Style.Triggers>
                                                     </Style>
@@ -1396,7 +1481,7 @@
                                         </Track.Thumb>
                                     </Track>
 
-                                    <Grid Grid.Column="2" Margin="-1,0" Width="17" Height="17">
+                                    <Grid Grid.Column="2" Width="17" Height="17">
                                         <RepeatButton x:Name="PART_LineRightButton"
                                                       Command="{Binding Source={x:Static ScrollBar.LineRightCommand}}"
                                                       Style="{DynamicResource AJut_Style_ButtonBase}"/>

--- a/libs/AJut.UX.Wpf/Resources/ThemedControlStylesBase.xaml
+++ b/libs/AJut.UX.Wpf/Resources/ThemedControlStylesBase.xaml
@@ -334,7 +334,7 @@
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type ButtonBase}">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}"
-                            Background="{TemplateBinding Background}">
+                            Background="{TemplateBinding Background}" CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}">
                         <ContentPresenter Content="{TemplateBinding Content}" ContentTemplate="{TemplateBinding ContentTemplate}" Margin="{TemplateBinding Padding}"
                                           HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                           VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
@@ -487,8 +487,8 @@
                             </MultiBinding>
                         </Grid.Margin>
                         <Border x:Name="BorderRoot" 
-                            BorderBrush="{TemplateBinding BorderBrush}" 
-                            CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}">
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}">
                             <Border.BorderThickness>
                                 <MultiBinding Converter="{ajut_themext:TabItemBorderThicknessConverter}">
                                     <Binding RelativeSource="{RelativeSource AncestorType={x:Type TabItem}}"/>
@@ -614,7 +614,8 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type TextBox}">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}">
+                    <Border BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" Background="{TemplateBinding Background}"
+                            CornerRadius="{ajut:TemplateBinding Path=(ajut_ap:BorderXTA.CornerRadius)}">
                         <ScrollViewer x:Name="PART_ContentHost" Margin="{TemplateBinding Padding}"/>
                     </Border>
                 </ControlTemplate>

--- a/libs/AJut.UX.Wpf/Theming/AJutStyleExtensionsForBuiltInWpfControls/AJutThemedListControlXTA.cs
+++ b/libs/AJut.UX.Wpf/Theming/AJutStyleExtensionsForBuiltInWpfControls/AJutThemedListControlXTA.cs
@@ -1,0 +1,13 @@
+﻿namespace AJut.UX.Theming.AJutStyleExtensionsForBuiltInWpfControls
+{
+    using System.Windows;
+
+    public class AJutThemedListControlXTA
+    {
+        private static readonly APUtilsRegistrationHelper APUtils = new APUtilsRegistrationHelper(typeof(AJutThemedListControlXTA));
+
+        public static DependencyProperty ListItemsShowHoverProperty = APUtils.Register(GetListItemsShowHover, SetListItemsShowHover, new FrameworkPropertyMetadata(true, FrameworkPropertyMetadataOptions.Inherits));
+        public static bool GetListItemsShowHover (DependencyObject obj) => (bool)obj.GetValue(ListItemsShowHoverProperty);
+        public static void SetListItemsShowHover (DependencyObject obj, bool value) => obj.SetValue(ListItemsShowHoverProperty, value);
+    }
+}

--- a/libs/AJut.UX.Wpf/Theming/AppThemeManager.cs
+++ b/libs/AJut.UX.Wpf/Theming/AppThemeManager.cs
@@ -135,6 +135,11 @@
             private set => this.SetAndRaiseIfChanged(ref m_currentTheme, value);
         }
 
+        /// <summary>
+        /// Flags that control the theme from a global xaml perspective
+        /// </summary>
+        public static Flags GlobalBindingFlags { get; } = new Flags();
+
         // =========================[ Utility Methods ]=============================
 
         public static eAppTheme GetWindowsUserAppThemeSetting ()
@@ -220,6 +225,17 @@
                 this.AlterApplicationTheme(GetWindowsUserAppThemeSetting());
             }
         }
+
+        // =========================[ Utility Classes ]=============================
+        public class Flags : NotifyPropertyChanged
+        {
+            private bool m_listItemsShowHover = true;
+            public bool ListItemsShowHover
+            {
+                get => m_listItemsShowHover;
+                set => this.SetAndRaiseIfChanged(ref m_listItemsShowHover, value);
+            }
+        }
     }
 }
 
@@ -245,4 +261,3 @@ namespace AJut.UX.Themeing
 
     }
 }
-

--- a/test/AJut.Core.Tests/AJut.Core.Tests.csproj
+++ b/test/AJut.Core.Tests/AJut.Core.Tests.csproj
@@ -6,10 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\libs\AJut.Core\AJut.Core.csproj" />

--- a/test/AJut.Core.Tests/IO.FileHelpersTests.cs
+++ b/test/AJut.Core.Tests/IO.FileHelpersTests.cs
@@ -19,6 +19,7 @@
         [TestMethod]
         public void FileHelpers_GenerateEmbeddedResourceStream_ReturnsValidStream()
         {
+            var type = typeof(FileHelpersTests);
             string[] manifestResources = typeof(FileHelpersTests).Assembly.GetManifestResourceNames();
             Console.WriteLine(String.Join("\n", manifestResources));
 

--- a/test/AJut.Core.Tests/ResourceFetcher.cs
+++ b/test/AJut.Core.Tests/ResourceFetcher.cs
@@ -2,6 +2,7 @@
 {
     using System.IO;
     using System.Reflection;
+    using AJut.IO;
 
     public static class ResourceFetcher
     {
@@ -11,8 +12,7 @@
         /// <param name="resourceName">A path to the resource in 'dir/name' format</param>
         public static Stream Get(string resourceName)
         {
-            string fullResourceName = string.Format("{0}.{1}", Assembly.GetCallingAssembly().GetName().Name, resourceName.Replace('/', '.'));
-            return typeof(ResourceFetcher).Assembly.GetManifestResourceStream(fullResourceName);
+            return FileHelpers.GetEmbeddedResourceStream(resourceName);
         }
 
         /// <summary>


### PR DESCRIPTION
* Scroll bars work properly, and inherit properly for list & textbox controls
* List items now highlight by default on hover
* List hover now shows differently and over selection
* List highlight can be turned off via themedlistcontrolxta
* Results now have tostring
* Buttons in the default theme now respect cvorner radius
* Fixed small issue where RunOnetimeSetup was generating empty folders when a shared name was used
* Making FlatTreeList toggle expansion on double click (configurable if you hate it for w/e reason)