### PR TITLE
Fixing auto publisher

### DIFF
--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    if: github.event.pull_request.merged == false || !contains(github.event.pull_request.labels.*.name, 'publish-nuget')
 
     steps:
     - name: Checkout code

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 !app.manifest
 !*.appxmanifest
 !launchSettings.json
+!ProjectOrder.json
 !*.pubxml
 
 # ============[ And finally nix these ]=========================

--- a/ProjectOrder.json
+++ b/ProjectOrder.json
@@ -1,0 +1,1 @@
+[ "AJut.Core", "AJut.UX", "AJut.UX.Wpf", "AJut.UX.WinUI3" ]


### PR DESCRIPTION
build and test doesn't need to run so much
ProjectOrder.json was accidentally git ignored :)