### PR TITLE
Flat tree update reversed ordering

### DIFF
--- a/libs/AJut.Core/AJut.Core.csproj
+++ b/libs/AJut.Core/AJut.Core.csproj
@@ -16,7 +16,7 @@
     <Description>C# / dotnet 8 utility library, created by AJ Badarni. Logger, Json parsing/building, extensions, undo/redo, math, tree logic, and more.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
-    <Version>1.5.0.118</Version>
+    <Version>1.5.1.120</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\.editorconfig" Link=".editorconfig" />

--- a/libs/AJut.Core/Storage/ObservableTree/ObservableFlatTreeStore.cs
+++ b/libs/AJut.Core/Storage/ObservableTree/ObservableFlatTreeStore.cs
@@ -19,6 +19,7 @@
         private delegate int IndexGenerator (TNode parent, int childIndexOnParent);
         private TNode m_rootNode;
         private bool m_includeRoot = true;
+        private eSiblingOrder m_siblingOrder = eSiblingOrder.Forward;
         private IndexGenerator m_indexGenerator;
 
         static ObservableFlatTreeStore ()
@@ -62,6 +63,24 @@
                     this.Items.Add(this.Observe(child));
                 }
             }
+        }
+
+        /// <summary>
+        /// Sibling iteration order applied while building the flat list from the source tree.
+        /// MUST be set BEFORE assigning <see cref="RootNode"/> - the property is captured into the
+        /// initial flat-build traversal and is not honored if changed after.
+        /// <para>
+        /// Note: this is wired into the initial-build and subtree-insertion traversals only. When the
+        /// store is fed nodes that have already absorbed sibling reversal at a higher layer (e.g.
+        /// AJut.UX.FlatTreeItem wrapping IObservableTreeNode sources), leave this at <see cref="eSiblingOrder.Forward"/>
+        /// to avoid double-reversal. <see cref="DetermineInsertIndex"/> still expects the visual
+        /// (already-reversed) index from the source ChildInserted event.
+        /// </para>
+        /// </summary>
+        public eSiblingOrder SiblingOrder
+        {
+            get => m_siblingOrder;
+            set => m_siblingOrder = value;
         }
 
         public bool IncludeRoot
@@ -132,7 +151,14 @@
                 return Enumerable.Empty<TNode>();
             }
 
-            return TreeTraversal<IObservableTreeNode>.All(m_rootNode, includeSelf: this.IncludeRoot, strategy: eTraversalStrategy.DepthFirst).OfType<TNode>();
+            var traversalParameters = new TreeTraversalParameters<IObservableTreeNode>(
+                m_rootNode,
+                eTraversalFlowDirection.ThroughChildren,
+                eTraversalStrategy.DepthFirst)
+            {
+                SiblingOrder = m_siblingOrder,
+            };
+            return TreeTraversal<IObservableTreeNode>.All(m_rootNode, traversalParameters, includeSelf: this.IncludeRoot).OfType<TNode>();
         }
 
         protected TNode Observe (TNode node)
@@ -245,7 +271,7 @@
             Debug.Assert(index >= 0 && index <= this.Items.Count, $"Index {index} is out of range for {nameof(ObservableFlatTreeStore)} with item count of {this.Items.Count}");
 
             List<TNode> addedNodes = new List<TNode>();
-            foreach (TNode child in TreeTraversal<IObservableTreeNode>.All(node).OfType<TNode>())
+            foreach (TNode child in this.EnumerateSubtreeForFlatList(node))
             {
                 this.Items.Insert(index++, this.Observe(child));
             }
@@ -257,13 +283,25 @@
         {
             List<TNode> removedNodes = new List<TNode>();
 
-            foreach (TNode toRemove in TreeTraversal<IObservableTreeNode>.All(node).OfType<TNode>())
+            foreach (TNode toRemove in this.EnumerateSubtreeForFlatList(node))
             {
                 this.Items.Remove(this.Disregard(toRemove));
                 removedNodes.Add(toRemove);
             }
 
             this.NodesRemoved?.Invoke(this, new EventArgs<List<TNode>>(removedNodes));
+        }
+
+        private IEnumerable<TNode> EnumerateSubtreeForFlatList (TNode node)
+        {
+            var traversalParameters = new TreeTraversalParameters<IObservableTreeNode>(
+                node,
+                eTraversalFlowDirection.ThroughChildren,
+                eTraversalStrategy.DepthFirst)
+            {
+                SiblingOrder = m_siblingOrder,
+            };
+            return TreeTraversal<IObservableTreeNode>.All(node, traversalParameters).OfType<TNode>();
         }
 
         private void Node_ChildInserted (object sender, TreeNodeInsertedEventArgs e)

--- a/libs/AJut.Core/Tree/Helpers/MiscDescriptors.cs
+++ b/libs/AJut.Core/Tree/Helpers/MiscDescriptors.cs
@@ -25,6 +25,18 @@
     }
 
     /// <summary>
+    /// Orthogonal to <see cref="eTraversalFlowDirection"/> - controls only the order siblings are
+    /// visited at each level when traversing through children. Forward is the normal source order;
+    /// Reversed walks siblings highest-source-index-first at every level (a layers-panel view).
+    /// Node paths still address forward source indices.
+    /// </summary>
+    public enum eSiblingOrder
+    {
+        Forward,
+        Reversed,
+    }
+
+    /// <summary>
     /// The strategy used to traverse the tree.
     /// Default is ThroughChildrenBreadthFirst
     /// All the options after ThroughParents/ThroughChildren are modifiers for ThroughChildren, and will be ignored for ThroughParents

--- a/libs/AJut.Core/Tree/TreeIter.cs
+++ b/libs/AJut.Core/Tree/TreeIter.cs
@@ -430,8 +430,39 @@
                 return;
             }
 
+            IEnumerable<TTreeNode> childSource = m_traversalParameters.GetChildrenMethod(this.Target);
+
+            // Reversed sibling iteration walks the same children backwards. Node-path indices stay
+            // forward (source-space) so paths remain compatible with NodeAt and friends.
+            if (m_traversalParameters.SiblingOrder == eSiblingOrder.Reversed)
+            {
+                IList<TTreeNode> childList = childSource as IList<TTreeNode> ?? childSource.ToList();
+                for (int sourceIndex = childList.Count - 1; sourceIndex >= 0; --sourceIndex)
+                {
+                    TTreeNode child = childList[sourceIndex];
+                    if (child == null || (targetChildStartIndex != -1 && sourceIndex < targetChildStartIndex))
+                    {
+                        continue;
+                    }
+
+                    if (this.IsUniqueInIteration(child))
+                    {
+                        if (targetChildStartIndex != -1)
+                        {
+                            nextEvals.Add(new TreeEvalItem<TTreeNode>(child, new TreeNodePath(this.TargetPath)));
+                        }
+                        else
+                        {
+                            var newNodePath = this.TargetPath.CopyAndAddToPath(sourceIndex);
+                            nextEvals.Add(new TreeEvalItem<TTreeNode>(child, newNodePath));
+                        }
+                    }
+                }
+                return;
+            }
+
             int childIndex = 0;
-            foreach (TTreeNode child in m_traversalParameters.GetChildrenMethod(this.Target))
+            foreach (TTreeNode child in childSource)
             {
                 int currentChildIndex = childIndex++;
                 if (child == null || (targetChildStartIndex != -1 && currentChildIndex < targetChildStartIndex))

--- a/libs/AJut.Core/Tree/TreeTraversal.cs
+++ b/libs/AJut.Core/Tree/TreeTraversal.cs
@@ -159,6 +159,26 @@ namespace AJut.Tree
         }
 
         /// <summary>
+        /// All-nodes traversal taking pre-built <see cref="TreeTraversalParameters{TTreeNode}"/> so callers
+        /// can opt in to options like <see cref="TreeTraversalParameters{TTreeNode}.SiblingOrder"/> without
+        /// the shortcut overloads having to grow another argument.
+        /// </summary>
+        public static IEnumerable<TTreeNode> All (TTreeNode start, TreeTraversalParameters<TTreeNode> traversalParameters, bool includeSelf = true)
+        {
+            TreeIter<TTreeNode> iter = CreateIterator(start, traversalParameters);
+            if (!includeSelf)
+            {
+                ++iter;
+            }
+
+            while (iter != TreeIter<TTreeNode>.End)
+            {
+                yield return iter.Node;
+                ++iter;
+            }
+        }
+
+        /// <summary>
         /// Creates an iterator for iterating over all nodes which pass a predicate
         /// </summary>
         /// <param name="start">The starting point</param>
@@ -389,6 +409,49 @@ namespace AJut.Tree
                 {
                     return _DoFindNextSiblingOrCousin(parent);
                 }
+            }
+        }
+
+        public static TTreeNode FindPreviousSiblingOrCousin (TTreeNode start, GetTreeNodeChildren<TTreeNode> getChildrenMethodOverride = null, GetTreeNodeParent<TTreeNode> getParentMethodOverride = null)
+        {
+            return FindPreviousSiblingOrCousin(null, start, getChildrenMethodOverride, getParentMethodOverride);
+        }
+        public static TTreeNode FindPreviousSiblingOrCousin (TTreeNode root, TTreeNode start, GetTreeNodeChildren<TTreeNode> getChildrenMethodOverride = null, GetTreeNodeParent<TTreeNode> getParentMethodOverride = null)
+        {
+            root ??= FindRoot(start, getParentMethodOverride);
+            var getChildren = getChildrenMethodOverride ?? GetChildrenMethod;
+            var getParent = getParentMethodOverride ?? GetParentMethod;
+            return _DoFindPrev(start);
+
+            TTreeNode _DoFindPrev (TTreeNode eval)
+            {
+                if (eval == root)
+                {
+                    return null;
+                }
+
+                var parent = getParent(eval);
+                if (parent == null)
+                {
+                    return null;
+                }
+
+                TTreeNode prev = null;
+                foreach (var sibling in getChildren(parent))
+                {
+                    if (sibling == eval)
+                    {
+                        break;
+                    }
+                    prev = sibling;
+                }
+
+                if (prev != null)
+                {
+                    return prev;
+                }
+
+                return _DoFindPrev(parent);
             }
         }
 

--- a/libs/AJut.Core/Tree/TreeTraversalParameters.cs
+++ b/libs/AJut.Core/Tree/TreeTraversalParameters.cs
@@ -23,6 +23,14 @@
         public eTraversalStrategy ChildTraversalStrategy { get; set; }
 
         /// <summary>
+        /// Order siblings are iterated at each level when traversing through children. Default is Forward
+        /// (source order). Reversed iterates highest-source-index-first at every level, with node paths
+        /// still pointing at forward source indices. Ignored for ThroughParents and ReversedThroughChildren
+        /// flow directions.
+        /// </summary>
+        public eSiblingOrder SiblingOrder { get; set; }
+
+        /// <summary>
         /// What type matching should be done? Used in "FirstChildOfType" type of evaluations.
         /// </summary>
         public TypeEval TypeMatching { get; set; }
@@ -106,6 +114,7 @@
             this.Root = root;
             this.FlowDirection = flowDirection;
             this.ChildTraversalStrategy = strategy;
+            this.SiblingOrder = eSiblingOrder.Forward;
             this.TypeMatching = null;
             this.Predicate = null;
             this.PruneAfterFirstFind = false;

--- a/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
+++ b/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
@@ -18,7 +18,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsPackageType>None</WindowsPackageType>
-    <Version>1.1.1.119</Version>
+    <Version>1.1.2.120</Version>
     <!-- =========[ NuGet packaging - ensure XBF + PRI resources are included ]======== -->
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/libs/AJut.UX.WinUI3/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.WinUI3/Controls/FlatTreeListControl.cs
@@ -104,9 +104,12 @@ namespace AJut.UX.Controls
         {
             m_store.RootNode?.DisposeTree();
             m_store.IncludeRoot = this.IncludeRoot;
+            // The store stays Forward even when SiblingDisplayOrder=Reversed - FlatTreeItem
+            // absorbs reversal in its own base.Children, so the store sees the visible (reversed)
+            // children directly and forward math is correct.
             m_store.RootNode = newRoot == null
                 ? null
-                : FlatTreeItem.CreateRoot(newRoot, this.TreeDepthIndentSize, this.StartItemsExpanded);
+                : FlatTreeItem.CreateRoot(newRoot, this.TreeDepthIndentSize, this.StartItemsExpanded, this.SiblingDisplayOrder);
         }
 
         public static readonly DependencyProperty RootItemsSourceProperty = DPUtils.Register(_ => _.RootItemsSource, (d, e) => d.OnRootItemsSourceChanged(e.OldValue, e.NewValue));
@@ -120,7 +123,7 @@ namespace AJut.UX.Controls
             m_store.RootNode?.DisposeTree();
             m_store.IncludeRoot = false;
             m_store.RootNode = FlatTreeItem.CreateUberRoot(
-                newValue ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize);
+                newValue ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize, startExpanded: false, this.SiblingDisplayOrder);
 
             if (oldValue is INotifyCollectionChanged oldObservable)
             {
@@ -224,6 +227,18 @@ namespace AJut.UX.Controls
         {
             get => (bool)this.GetValue(StartItemsExpandedProperty);
             set => this.SetValue(StartItemsExpandedProperty, value);
+        }
+
+        // Per-level sibling iteration order for the visible flat list. Forward is the default - source
+        // order top-to-bottom. Reversed makes every parent's children iterate highest-source-index-first
+        // (a layers-panel feel). Drag-drop still surfaces source-space InsertIndex values, so consumers
+        // don't have to be reverse-aware.
+        // Setting this re-creates the store from the current root if one exists.
+        public static readonly DependencyProperty SiblingDisplayOrderProperty = DPUtils.Register(_ => _.SiblingDisplayOrder, eSiblingOrder.Forward, (d, e) => d.RebuildStoreFromCurrentRoot());
+        public eSiblingOrder SiblingDisplayOrder
+        {
+            get => (eSiblingOrder)this.GetValue(SiblingDisplayOrderProperty);
+            set => this.SetValue(SiblingDisplayOrderProperty, value);
         }
 
         public static readonly DependencyProperty ItemTemplateProperty = DPUtils.Register(_ => _.ItemTemplate, (d, e) => d.OnItemTemplateChanged());
@@ -760,7 +775,24 @@ namespace AJut.UX.Controls
             // current full state of RootItemsSource on every change instead.
             m_store.RootNode?.DisposeTree();
             m_store.RootNode = FlatTreeItem.CreateUberRoot(
-                this.RootItemsSource ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize);
+                this.RootItemsSource ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize, startExpanded: false, this.SiblingDisplayOrder);
+        }
+
+        private void RebuildStoreFromCurrentRoot ()
+        {
+            // SiblingDisplayOrder is captured into FlatTreeItem at construction; the only safe response
+            // to a live change is a full rebuild of the current root (or uber root) so the new mode
+            // applies consistently.
+            if (this.RootItemsSource != null)
+            {
+                this.OnRootItemsSourceChanged(this.RootItemsSource, this.RootItemsSource);
+                return;
+            }
+
+            if (this.Root != null)
+            {
+                this.OnRootChanged(this.Root);
+            }
         }
 
         // ===========[ Apply helpers ]============================================
@@ -1014,10 +1046,12 @@ namespace AJut.UX.Controls
                 return;
             }
 
-            // Compute drop target
+            // Compute drop target. Sibling order is threaded in so the returned InsertIndex stays
+            // source-space even when the visual list is reversed.
             double indentSize = this.TreeDepthIndentSize;
             var dropTarget = FlatTreeDragDropManager.ComputeDropTarget(
-                m_store, m_dragItems, hoverIndex, cursorYFraction, cursorInListView.X, indentSize
+                m_store, m_dragItems, hoverIndex, cursorYFraction, cursorInListView.X, indentSize,
+                this.SiblingDisplayOrder
             );
 
             // Validate

--- a/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
+++ b/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
@@ -15,7 +15,7 @@
     <PackageTags>c#;dotnet;wpf;theming;controls;converters;app;utilities</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.5.0.118</Version>
+    <Version>1.5.1.120</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />

--- a/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
@@ -92,9 +92,12 @@ namespace AJut.UX.Controls
         private void OnRootChanged (IObservableTreeNode newRoot)
         {
             this.Items.IncludeRoot = this.IncludeRoot;
+            // Store stays Forward even when SiblingDisplayOrder=Reversed - FlatTreeItem absorbs
+            // reversal in its own base.Children, so the store sees the visible (reversed) children
+            // directly and forward math is correct.
             this.Items.RootNode = newRoot == null
                 ? null
-                : FlatTreeItem.CreateRoot(newRoot, this.TreeDepthIndentSize, this.StartItemsExpanded);
+                : FlatTreeItem.CreateRoot(newRoot, this.TreeDepthIndentSize, this.StartItemsExpanded, this.SiblingDisplayOrder);
         }
 
         public static readonly DependencyProperty RootItemsSourceProperty = DPUtils.Register(_ => _.RootItemsSource, (d, e) => d.OnRootItemsSourceChanged(e.OldValue, e.NewValue));
@@ -109,7 +112,8 @@ namespace AJut.UX.Controls
             // subscribed (observed) by the store - it will be rebuilt from scratch on each
             // collection change rather than incrementally updated via events on the root.
             this.IncludeRoot = false;
-            this.Items.RootNode = FlatTreeItem.CreateUberRoot(newValue ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize);
+            this.Items.RootNode = FlatTreeItem.CreateUberRoot(
+                newValue ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize, startExpanded: false, this.SiblingDisplayOrder);
 
             if (oldValue is INotifyCollectionChanged oldObservable)
             {
@@ -156,6 +160,18 @@ namespace AJut.UX.Controls
         {
             get => (bool)this.GetValue(StartItemsExpandedProperty);
             set => this.SetValue(StartItemsExpandedProperty, value);
+        }
+
+        // Per-level sibling iteration order for the visible flat list. Forward is the default - source
+        // order top-to-bottom. Reversed makes every parent's children iterate highest-source-index-first
+        // (a layers-panel feel). Drag-drop still surfaces source-space InsertIndex values, so consumers
+        // don't have to be reverse-aware.
+        // Setting this re-creates the store from the current root if one exists.
+        public static readonly DependencyProperty SiblingDisplayOrderProperty = DPUtils.Register(_ => _.SiblingDisplayOrder, eSiblingOrder.Forward, (d, e) => d.RebuildStoreFromCurrentRoot());
+        public eSiblingOrder SiblingDisplayOrder
+        {
+            get => (eSiblingOrder)this.GetValue(SiblingDisplayOrderProperty);
+            set => this.SetValue(SiblingDisplayOrderProperty, value);
         }
 
         // ===================[Display Dependency Properties]===================
@@ -707,7 +723,24 @@ namespace AJut.UX.Controls
             // so InsertChild/RemoveChild on the uber root fires events no one hears. Rebuild from the
             // current full state of RootItemsSource on every change instead.
             this.Items.RootNode = FlatTreeItem.CreateUberRoot(
-                this.RootItemsSource ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize);
+                this.RootItemsSource ?? Enumerable.Empty<IObservableTreeNode>(), this.TreeDepthIndentSize, startExpanded: false, this.SiblingDisplayOrder);
+        }
+
+        private void RebuildStoreFromCurrentRoot ()
+        {
+            // SiblingDisplayOrder is captured into FlatTreeItem at construction; the only safe response
+            // to a live change is a full rebuild of the current root (or uber root) so the new mode
+            // applies consistently.
+            if (this.RootItemsSource != null)
+            {
+                this.OnRootItemsSourceChanged(this.RootItemsSource, this.RootItemsSource);
+                return;
+            }
+
+            if (this.Root != null)
+            {
+                this.OnRootChanged(this.Root);
+            }
         }
 
         // ============================[Drag/Drop Mouse Handlers]================================
@@ -900,9 +933,12 @@ namespace AJut.UX.Controls
                 return;
             }
 
+            // Sibling order is threaded in so the returned InsertIndex stays source-space even when
+            // the visual list is reversed.
             double indentSize = this.TreeDepthIndentSize;
             var dropTarget = FlatTreeDragDropManager.ComputeDropTarget(
-                this.Items, m_dragItems, hoverIndex, cursorYFraction, cursorInListBox.X, indentSize
+                this.Items, m_dragItems, hoverIndex, cursorYFraction, cursorInListBox.X, indentSize,
+                this.SiblingDisplayOrder
             );
 
             if (dropTarget == null

--- a/libs/AJut.UX/AJut.UX.csproj
+++ b/libs/AJut.UX/AJut.UX.csproj
@@ -14,7 +14,7 @@
     <PackageTags>c#;dotnet;theming;controls;converters;app;utilities</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.0.118</Version>
+    <Version>1.1.1.120</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\ajut-logo-128.png">

--- a/libs/AJut.UX/FlatTree/FlatTreeDragDropManager.cs
+++ b/libs/AJut.UX/FlatTree/FlatTreeDragDropManager.cs
@@ -97,13 +97,16 @@ namespace AJut.UX
         /// <param name="cursorYFraction">0.0 = top of row, 1.0 = bottom of row.</param>
         /// <param name="cursorX">Horizontal pixel position of the cursor within the list area.</param>
         /// <param name="indentSize">Pixels per tree depth level (TreeDepthIndentSize).</param>
+        /// <param name="siblingOrder">Visual sibling order of the tree. Reversed makes the returned
+        /// InsertIndex still source-space, so consumers do not need to be reverse-aware.</param>
         public static FlatTreeDropTarget ComputeDropTarget (
             ObservableFlatTreeStore<FlatTreeItem> store,
             FlatTreeItem[] draggedItems,
             int hoverStoreIndex,
             double cursorYFraction,
             double cursorX,
-            double indentSize)
+            double indentSize,
+            eSiblingOrder siblingOrder = eSiblingOrder.Forward)
         {
             if (store == null || store.Count == 0 || draggedItems == null || draggedItems.Length == 0)
             {
@@ -141,7 +144,7 @@ namespace AJut.UX
                 return FlatTreeDropTarget.Invalid;
             }
 
-            return ComputeDropTargetForGap(above, below, cursorX, indentSize);
+            return ComputeDropTargetForGap(above, below, cursorX, indentSize, siblingOrder);
         }
 
         /// <summary>
@@ -152,7 +155,8 @@ namespace AJut.UX
             FlatTreeItem above,
             FlatTreeItem below,
             double cursorX,
-            double indentSize)
+            double indentSize,
+            eSiblingOrder siblingOrder = eSiblingOrder.Forward)
         {
             if (above == null)
             {
@@ -190,7 +194,7 @@ namespace AJut.UX
             int targetDepth = Math.Clamp(depthFromCursor, minDepth, maxDepth);
 
             // 4. Compute the actual parent and insert index for this depth
-            return ComputeParentAndIndex(above, targetDepth);
+            return ComputeParentAndIndex(above, targetDepth, siblingOrder);
         }
 
         // ===========[ Validation ]================================================
@@ -317,12 +321,16 @@ namespace AJut.UX
 
         // ===========[ Private Helpers ]==========================================
 
-        private static FlatTreeDropTarget ComputeParentAndIndex (FlatTreeItem above, int targetDepth)
+        private static FlatTreeDropTarget ComputeParentAndIndex (FlatTreeItem above, int targetDepth, eSiblingOrder siblingOrder)
         {
             if (targetDepth == above.TreeDepth + 1)
             {
-                // Insert as first child of 'above'
-                return new FlatTreeDropTarget(above.Source, 0, targetDepth);
+                // Insert as the visually-first child of 'above'. In Forward that is source index 0,
+                // in Reversed it is the end of the source list (visually-first = source-last).
+                int firstChildInsert = siblingOrder == eSiblingOrder.Reversed
+                    ? above.Source.Children.Count
+                    : 0;
+                return new FlatTreeDropTarget(above.Source, firstChildInsert, targetDepth);
             }
 
             // Walk up from 'above' to find the item at targetDepth
@@ -337,7 +345,9 @@ namespace AJut.UX
                 return FlatTreeDropTarget.Invalid;
             }
 
-            // Insert as next sibling of target
+            // Insert as the visually-next sibling of target. Forward: source idx + 1 (push target up
+            // in source). Reversed: source idx of target (push target later in source so visually it
+            // moves down below the new item).
             IObservableTreeNode sourceNode = target.Source;
             IObservableTreeNode parentNode = sourceNode.Parent;
             int indexInParent = IndexOfChild(parentNode, sourceNode);
@@ -346,7 +356,10 @@ namespace AJut.UX
                 return FlatTreeDropTarget.Invalid;
             }
 
-            return new FlatTreeDropTarget(parentNode, indexInParent + 1, targetDepth);
+            int insertIndex = siblingOrder == eSiblingOrder.Reversed
+                ? indexInParent
+                : indexInParent + 1;
+            return new FlatTreeDropTarget(parentNode, insertIndex, targetDepth);
         }
 
         private static int IndexOfChild (IObservableTreeNode parent, IObservableTreeNode child)

--- a/libs/AJut.UX/FlatTree/FlatTreeItem.cs
+++ b/libs/AJut.UX/FlatTree/FlatTreeItem.cs
@@ -46,17 +46,19 @@ namespace AJut.UX
         private bool m_isSelected;
         private bool m_isSelectable = true;
         private double m_treeDepthIndentSize = 16.0;
+        private eSiblingOrder m_siblingOrder = eSiblingOrder.Forward;
         private EventHandler<EventArgs<bool>> m_canHaveChildrenChangedHandler;
 
         // ===========[ Construction ]=============================================
         // Private - use factory methods.
         private FlatTreeItem () { }
 
-        private FlatTreeItem (IObservableTreeNode source, FlatTreeItem parent, double treeDepthIndentSize, bool startExpanded)
+        private FlatTreeItem (IObservableTreeNode source, FlatTreeItem parent, double treeDepthIndentSize, bool startExpanded, eSiblingOrder siblingOrder)
         {
             m_source = source;
             m_parentItem = parent;
             m_treeDepthIndentSize = treeDepthIndentSize;
+            m_siblingOrder = siblingOrder;
             m_isExpandable = source.CanHaveChildren;
 
             // If the source tracks its own expansion state, honour it over the caller's startExpanded.
@@ -70,11 +72,15 @@ namespace AJut.UX
             source.ChildInserted += this.Source_ChildInserted;
             source.ChildRemoved += this.Source_ChildRemoved;
 
-            // Build the child hierarchy. If startExpanded, put children into
-            // base.Children (visible); otherwise into m_hiddenChildren.
-            foreach (IObservableTreeNode child in source.Children)
+            // Build the child hierarchy. base.Children / m_hiddenChildren are kept in VISUAL order -
+            // so in Reversed mode we iterate the source list backwards and still append at the end.
+            // The whole rest of the control treats base.Children as the visible order.
+            IEnumerable<IObservableTreeNode> sourceChildren = siblingOrder == eSiblingOrder.Reversed
+                ? source.Children.Reverse()
+                : source.Children;
+            foreach (IObservableTreeNode child in sourceChildren)
             {
-                var childItem = new FlatTreeItem(child, this, treeDepthIndentSize, startExpanded);
+                var childItem = new FlatTreeItem(child, this, treeDepthIndentSize, startExpanded, siblingOrder);
                 if (startExpanded)
                 {
                     base.InsertChild(base.Children.Count, childItem);
@@ -95,29 +101,36 @@ namespace AJut.UX
         /// <summary>
         /// Creates a single-root flat tree item hierarchy from the given observable source tree.
         /// </summary>
-        public static FlatTreeItem CreateRoot (IObservableTreeNode source, double treeDepthIndentSize = 16.0, bool startExpanded = false)
+        public static FlatTreeItem CreateRoot (IObservableTreeNode source, double treeDepthIndentSize = 16.0, bool startExpanded = false, eSiblingOrder siblingOrder = eSiblingOrder.Forward)
         {
-            return new FlatTreeItem(source, null, treeDepthIndentSize, startExpanded);
+            return new FlatTreeItem(source, null, treeDepthIndentSize, startExpanded, siblingOrder);
         }
 
         /// <summary>
         /// Creates an invisible false root whose children are the given source roots (multi-root scenario).
         /// The false root itself is never shown; IncludeRoot=false on the store omits it.
         /// </summary>
-        public static FlatTreeItem CreateUberRoot (IEnumerable<IObservableTreeNode> roots, double treeDepthIndentSize = 16.0, bool startExpanded = false)
+        public static FlatTreeItem CreateUberRoot (IEnumerable<IObservableTreeNode> roots, double treeDepthIndentSize = 16.0, bool startExpanded = false, eSiblingOrder siblingOrder = eSiblingOrder.Forward)
         {
             var uber = new FlatTreeItem
             {
                 m_isFalseRoot = true,
                 m_treeDepthIndentSize = treeDepthIndentSize,
+                m_siblingOrder = siblingOrder,
                 m_isExpandable = true,
                 m_isExpanded = true,   // uber root always expanded (its children are the visible roots)
             };
 
+            // Multi-root layout: with Reversed the visually-topmost root is the last in the roots
+            // enumerable. Uber root mirrors the per-level reversal of regular children.
+            IEnumerable<IObservableTreeNode> orderedRoots = siblingOrder == eSiblingOrder.Reversed
+                ? roots.Reverse()
+                : roots;
+
             int index = 0;
-            foreach (IObservableTreeNode root in roots)
+            foreach (IObservableTreeNode root in orderedRoots)
             {
-                var childItem = new FlatTreeItem(root, uber, treeDepthIndentSize, startExpanded);
+                var childItem = new FlatTreeItem(root, uber, treeDepthIndentSize, startExpanded, siblingOrder);
                 // Uber root is always expanded, so children go into base.Children.
                 uber.InsertChild(index++, childItem);
             }
@@ -289,8 +302,18 @@ namespace AJut.UX
         // ===========[ Source event handlers ]====================================
         private void Source_ChildInserted (object sender, TreeNodeInsertedEventArgs e)
         {
-            var child = new FlatTreeItem((IObservableTreeNode)e.Node, this, m_treeDepthIndentSize, false);
-            this.InsertChild(e.InsertIndex, child);
+            var child = new FlatTreeItem((IObservableTreeNode)e.Node, this, m_treeDepthIndentSize, false, m_siblingOrder);
+            int insertIndex = e.InsertIndex;
+            if (m_siblingOrder == eSiblingOrder.Reversed)
+            {
+                // base.Children / m_hiddenChildren is the visible (reversed) list and at this point
+                // hasn't been updated yet. Source-end insert (highest source index) maps to visual 0,
+                // source-start insert maps to visual end - so the formula is preExistingCount - sourceIdx.
+                int visibleCount = m_isExpanded ? base.Children.Count : m_hiddenChildren.Count;
+                insertIndex = visibleCount - e.InsertIndex;
+            }
+
+            this.InsertChild(insertIndex, child);
         }
 
         private void Source_ChildRemoved (object sender, EventArgs<IObservableTreeNode> e)

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -501,64 +501,145 @@
                             <SymbolIconSource Symbol="List"/>
                         </TabViewItem.IconSource>
                         <TabViewItem.Content>
-                            <Grid Margin="8">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="*"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.Row="0" Text="FlatTreeListControl - expand/collapse tree nodes, multi-level nesting" FontStyle="Italic" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Selection indicator: 4px colored strip on the left edge (AJut signature selection style). Row background receives only a subtle tint." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
-                                <ajut:FlatTreeListControl Grid.Row="2"
-                                                          Root="{x:Bind TreeRoot}"
-                                                          IncludeRoot="True"
-                                                          StartItemsExpanded="True">
-                                    <ajut:FlatTreeListControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
-                                        </DataTemplate>
-                                    </ajut:FlatTreeListControl.ItemTemplate>
-                                </ajut:FlatTreeListControl>
-                            </Grid>
-                        </TabViewItem.Content>
-                    </TabViewItem>
+                            <TabView CanDragTabs="False" CanReorderTabs="False" IsAddTabButtonVisible="False" TabWidthMode="SizeToContent">
+                                <!-- Overview -->
+                                <TabViewItem Header="Overview" IsClosable="False" VerticalContentAlignment="Stretch">
+                                    <TabViewItem.Content>
+                                        <Grid Margin="8">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="*"/>
+                                            </Grid.RowDefinitions>
+                                            <TextBlock Grid.Row="0" Text="FlatTreeListControl - expand/collapse tree nodes, multi-level nesting" FontStyle="Italic" Margin="0,0,0,4"/>
+                                            <TextBlock Grid.Row="1" Text="Selection indicator: 4px colored strip on the left edge (AJut signature selection style). Row background receives only a subtle tint." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
+                                            <ajut:FlatTreeListControl Grid.Row="2"
+                                                                      Root="{x:Bind TreeRoot}"
+                                                                      IncludeRoot="True"
+                                                                      StartItemsExpanded="True">
+                                                <ajut:FlatTreeListControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                                                    </DataTemplate>
+                                                </ajut:FlatTreeListControl.ItemTemplate>
+                                            </ajut:FlatTreeListControl>
+                                        </Grid>
+                                    </TabViewItem.Content>
+                                </TabViewItem>
 
-                    <!-- ===[ FlatTree Drag/Drop ]=================================================== -->
-                    <TabViewItem Header="FlatTree Drag/Drop" IsClosable="False">
-                        <TabViewItem.IconSource>
-                            <SymbolIconSource Symbol="MoveToFolder"/>
-                        </TabViewItem.IconSource>
-                        <TabViewItem.Content>
-                            <Grid Margin="8">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="*"/>
-                                </Grid.RowDefinitions>
-                                <TextBlock Grid.Row="0" Text="FlatTreeListControl - Drag and Drop Reordering + SetSelection test" FontStyle="Italic" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Text="Drag items to reorder. X position determines target depth. Blue insertion line shows where item will land; dotted connector shows target parent." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
-                                <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
-                                    <Button Content="SetSelection: 3 scattered items" Click="SetSelectionScattered_OnClick"/>
-                                    <Button Content="SetSelection: all descendants of Scenes" Click="SetSelectionScenesDescendants_OnClick"/>
-                                    <Button Content="SetSelection: empty" Click="SetSelectionEmpty_OnClick"/>
-                                    <TextBlock x:Name="SetSelectionStatus" VerticalAlignment="Center" Opacity="0.8"/>
-                                </StackPanel>
-                                <ajut:FlatTreeListControl Grid.Row="3"
-                                                          x:Name="DragDropTree"
-                                                          Root="{x:Bind DragDropTreeRoot}"
-                                                          IncludeRoot="True"
-                                                          StartItemsExpanded="True"
-                                                          IsDragDropReorderEnabled="True"
-                                                          SelectionMode="Extended"
-                                                          SelectionChanged="DragDropTree_OnSelectionChanged">
-                                    <ajut:FlatTreeListControl.ItemTemplate>
-                                        <DataTemplate>
-                                            <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
-                                        </DataTemplate>
-                                    </ajut:FlatTreeListControl.ItemTemplate>
-                                </ajut:FlatTreeListControl>
-                            </Grid>
+                                <!-- Drag/Drop -->
+                                <TabViewItem Header="Drag/Drop" IsClosable="False" VerticalContentAlignment="Stretch">
+                                    <TabViewItem.Content>
+                                        <Grid Margin="8">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="*"/>
+                                            </Grid.RowDefinitions>
+                                            <TextBlock Grid.Row="0" Text="FlatTreeListControl - Drag and Drop Reordering + SetSelection test" FontStyle="Italic" Margin="0,0,0,4"/>
+                                            <TextBlock Grid.Row="1" Text="Drag items to reorder. X position determines target depth. Blue insertion line shows where item will land; dotted connector shows target parent." TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
+                                            <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
+                                                <Button Content="SetSelection: 3 scattered items" Click="SetSelectionScattered_OnClick"/>
+                                                <Button Content="SetSelection: all descendants of Scenes" Click="SetSelectionScenesDescendants_OnClick"/>
+                                                <Button Content="SetSelection: empty" Click="SetSelectionEmpty_OnClick"/>
+                                                <TextBlock x:Name="SetSelectionStatus" VerticalAlignment="Center" Opacity="0.8"/>
+                                            </StackPanel>
+                                            <ajut:FlatTreeListControl Grid.Row="3"
+                                                                      x:Name="DragDropTree"
+                                                                      Root="{x:Bind DragDropTreeRoot}"
+                                                                      IncludeRoot="True"
+                                                                      StartItemsExpanded="True"
+                                                                      IsDragDropReorderEnabled="True"
+                                                                      SelectionMode="Extended"
+                                                                      SelectionChanged="DragDropTree_OnSelectionChanged">
+                                                <ajut:FlatTreeListControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                                                    </DataTemplate>
+                                                </ajut:FlatTreeListControl.ItemTemplate>
+                                            </ajut:FlatTreeListControl>
+                                        </Grid>
+                                    </TabViewItem.Content>
+                                </TabViewItem>
+
+                                <!-- Sibling Order -->
+                                <TabViewItem Header="Sibling Order" IsClosable="False" VerticalContentAlignment="Stretch">
+                                    <TabViewItem.Content>
+                                        <Grid Margin="8">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="Auto"/>
+                                                <RowDefinition Height="*"/>
+                                            </Grid.RowDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="*"/>
+                                                <ColumnDefinition Width="8"/>
+                                                <ColumnDefinition Width="*"/>
+                                            </Grid.ColumnDefinitions>
+
+                                            <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Text="FlatTreeListControl SiblingDisplayOrder - left=Forward, right=Reversed. Both wrap the same source tree shape; drag-drop should produce identical source-space InsertIndex values."
+                                                       TextWrapping="Wrap" FontStyle="Italic" Opacity="0.75" Margin="0,0,0,4"/>
+                                            <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Text="Drop somewhere and watch the log below for the chosen TargetParent + InsertIndex (source-space)."
+                                                       TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
+
+                                            <TextBlock Grid.Row="2" Grid.Column="0" Text="Forward" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                            <TextBlock Grid.Row="2" Grid.Column="2" Text="Reversed (layers-panel style)" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+                                            <Grid Grid.Row="3" Grid.Column="0">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="*"/>
+                                                    <RowDefinition Height="120"/>
+                                                </Grid.RowDefinitions>
+                                                <ajut:FlatTreeListControl Grid.Row="0"
+                                                                          x:Name="SiblingOrderForwardTree"
+                                                                          Root="{x:Bind SiblingOrderForwardRoot}"
+                                                                          IncludeRoot="True"
+                                                                          StartItemsExpanded="True"
+                                                                          IsDragDropReorderEnabled="True"
+                                                                          SelectionMode="Extended"
+                                                                          SiblingDisplayOrder="Forward"
+                                                                          DragDropReorderRequested="SiblingOrderTree_OnReorder">
+                                                    <ajut:FlatTreeListControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                                                        </DataTemplate>
+                                                    </ajut:FlatTreeListControl.ItemTemplate>
+                                                </ajut:FlatTreeListControl>
+                                                <TextBox Grid.Row="1" x:Name="SiblingOrderForwardLog" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                                                         FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
+                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                            </Grid>
+
+                                            <Grid Grid.Row="3" Grid.Column="2">
+                                                <Grid.RowDefinitions>
+                                                    <RowDefinition Height="*"/>
+                                                    <RowDefinition Height="120"/>
+                                                </Grid.RowDefinitions>
+                                                <ajut:FlatTreeListControl Grid.Row="0"
+                                                                          x:Name="SiblingOrderReversedTree"
+                                                                          Root="{x:Bind SiblingOrderReversedRoot}"
+                                                                          IncludeRoot="True"
+                                                                          StartItemsExpanded="True"
+                                                                          IsDragDropReorderEnabled="True"
+                                                                          SelectionMode="Extended"
+                                                                          SiblingDisplayOrder="Reversed"
+                                                                          DragDropReorderRequested="SiblingOrderTree_OnReorder">
+                                                    <ajut:FlatTreeListControl.ItemTemplate>
+                                                        <DataTemplate>
+                                                            <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                                                        </DataTemplate>
+                                                    </ajut:FlatTreeListControl.ItemTemplate>
+                                                </ajut:FlatTreeListControl>
+                                                <TextBox Grid.Row="1" x:Name="SiblingOrderReversedLog" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                                                         FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
+                                                         ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                            </Grid>
+                                        </Grid>
+                                    </TabViewItem.Content>
+                                </TabViewItem>
+                            </TabView>
                         </TabViewItem.Content>
                     </TabViewItem>
 
@@ -779,86 +860,6 @@
                                                Text="A FAIL here is real - it means a subscription survived Dispose. A PASS does not prove the absence of all leaks (some subs may only manifest after specific operations like opening a tearoff). For deeper coverage, exercise the docking experience (open tabs, tear off, dock back) and re-run the cycle probe."/>
                                 </StackPanel>
                             </ScrollViewer>
-                        </TabViewItem.Content>
-                    </TabViewItem>
-
-                    <!-- ===[ Sibling Order (Reversed) ]============================================ -->
-                    <TabViewItem Header="Sibling Order" IsClosable="False" VerticalContentAlignment="Stretch">
-                        <TabViewItem.IconSource>
-                            <SymbolIconSource Symbol="Sort"/>
-                        </TabViewItem.IconSource>
-                        <TabViewItem.Content>
-                            <Grid Margin="8">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="Auto"/>
-                                    <RowDefinition Height="*"/>
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*"/>
-                                    <ColumnDefinition Width="8"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-
-                                <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Text="FlatTreeListControl SiblingDisplayOrder - left=Forward, right=Reversed. Both wrap the same source tree shape; drag-drop should produce identical source-space InsertIndex values."
-                                           TextWrapping="Wrap" FontStyle="Italic" Opacity="0.75" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Text="Drop somewhere and watch the log below for the chosen TargetParent + InsertIndex (source-space)."
-                                           TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
-
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Forward" FontWeight="SemiBold" Margin="0,0,0,4"/>
-                                <TextBlock Grid.Row="2" Grid.Column="2" Text="Reversed (layers-panel style)" FontWeight="SemiBold" Margin="0,0,0,4"/>
-
-                                <Grid Grid.Row="3" Grid.Column="0">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="*"/>
-                                        <RowDefinition Height="120"/>
-                                    </Grid.RowDefinitions>
-                                    <ajut:FlatTreeListControl Grid.Row="0"
-                                                              x:Name="SiblingOrderForwardTree"
-                                                              Root="{x:Bind SiblingOrderForwardRoot}"
-                                                              IncludeRoot="True"
-                                                              StartItemsExpanded="True"
-                                                              IsDragDropReorderEnabled="True"
-                                                              SelectionMode="Extended"
-                                                              SiblingDisplayOrder="Forward"
-                                                              DragDropReorderRequested="SiblingOrderTree_OnReorder">
-                                        <ajut:FlatTreeListControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
-                                            </DataTemplate>
-                                        </ajut:FlatTreeListControl.ItemTemplate>
-                                    </ajut:FlatTreeListControl>
-                                    <TextBox Grid.Row="1" x:Name="SiblingOrderForwardLog" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
-                                             FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
-                                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
-                                </Grid>
-
-                                <Grid Grid.Row="3" Grid.Column="2">
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="*"/>
-                                        <RowDefinition Height="120"/>
-                                    </Grid.RowDefinitions>
-                                    <ajut:FlatTreeListControl Grid.Row="0"
-                                                              x:Name="SiblingOrderReversedTree"
-                                                              Root="{x:Bind SiblingOrderReversedRoot}"
-                                                              IncludeRoot="True"
-                                                              StartItemsExpanded="True"
-                                                              IsDragDropReorderEnabled="True"
-                                                              SelectionMode="Extended"
-                                                              SiblingDisplayOrder="Reversed"
-                                                              DragDropReorderRequested="SiblingOrderTree_OnReorder">
-                                        <ajut:FlatTreeListControl.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
-                                            </DataTemplate>
-                                        </ajut:FlatTreeListControl.ItemTemplate>
-                                    </ajut:FlatTreeListControl>
-                                    <TextBox Grid.Row="1" x:Name="SiblingOrderReversedLog" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
-                                             FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
-                                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
-                                </Grid>
-                            </Grid>
                         </TabViewItem.Content>
                     </TabViewItem>
 

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -782,6 +782,86 @@
                         </TabViewItem.Content>
                     </TabViewItem>
 
+                    <!-- ===[ Sibling Order (Reversed) ]============================================ -->
+                    <TabViewItem Header="Sibling Order" IsClosable="False" VerticalContentAlignment="Stretch">
+                        <TabViewItem.IconSource>
+                            <SymbolIconSource Symbol="Sort"/>
+                        </TabViewItem.IconSource>
+                        <TabViewItem.Content>
+                            <Grid Margin="8">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="*"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="8"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Grid.Row="0" Grid.ColumnSpan="3" Text="FlatTreeListControl SiblingDisplayOrder - left=Forward, right=Reversed. Both wrap the same source tree shape; drag-drop should produce identical source-space InsertIndex values."
+                                           TextWrapping="Wrap" FontStyle="Italic" Opacity="0.75" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="1" Grid.ColumnSpan="3" Text="Drop somewhere and watch the log below for the chosen TargetParent + InsertIndex (source-space)."
+                                           TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"/>
+
+                                <TextBlock Grid.Row="2" Grid.Column="0" Text="Forward" FontWeight="SemiBold" Margin="0,0,0,4"/>
+                                <TextBlock Grid.Row="2" Grid.Column="2" Text="Reversed (layers-panel style)" FontWeight="SemiBold" Margin="0,0,0,4"/>
+
+                                <Grid Grid.Row="3" Grid.Column="0">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*"/>
+                                        <RowDefinition Height="120"/>
+                                    </Grid.RowDefinitions>
+                                    <ajut:FlatTreeListControl Grid.Row="0"
+                                                              x:Name="SiblingOrderForwardTree"
+                                                              Root="{x:Bind SiblingOrderForwardRoot}"
+                                                              IncludeRoot="True"
+                                                              StartItemsExpanded="True"
+                                                              IsDragDropReorderEnabled="True"
+                                                              SelectionMode="Extended"
+                                                              SiblingDisplayOrder="Forward"
+                                                              DragDropReorderRequested="SiblingOrderTree_OnReorder">
+                                        <ajut:FlatTreeListControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                                            </DataTemplate>
+                                        </ajut:FlatTreeListControl.ItemTemplate>
+                                    </ajut:FlatTreeListControl>
+                                    <TextBox Grid.Row="1" x:Name="SiblingOrderForwardLog" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                                             FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
+                                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                </Grid>
+
+                                <Grid Grid.Row="3" Grid.Column="2">
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="*"/>
+                                        <RowDefinition Height="120"/>
+                                    </Grid.RowDefinitions>
+                                    <ajut:FlatTreeListControl Grid.Row="0"
+                                                              x:Name="SiblingOrderReversedTree"
+                                                              Root="{x:Bind SiblingOrderReversedRoot}"
+                                                              IncludeRoot="True"
+                                                              StartItemsExpanded="True"
+                                                              IsDragDropReorderEnabled="True"
+                                                              SelectionMode="Extended"
+                                                              SiblingDisplayOrder="Reversed"
+                                                              DragDropReorderRequested="SiblingOrderTree_OnReorder">
+                                        <ajut:FlatTreeListControl.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                                            </DataTemplate>
+                                        </ajut:FlatTreeListControl.ItemTemplate>
+                                    </ajut:FlatTreeListControl>
+                                    <TextBox Grid.Row="1" x:Name="SiblingOrderReversedLog" IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                                             FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
+                                             ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+                                </Grid>
+                            </Grid>
+                        </TabViewItem.Content>
+                    </TabViewItem>
+
                     <!-- ===[ Dock Zone ]=========================================================== -->
                     <TabViewItem Header="Dock Zone" IsClosable="False" VerticalContentAlignment="Stretch">
                         <TabViewItem.IconSource>

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -205,6 +205,24 @@ namespace AJutShowRoomWinUI
         public ShowRoomTreeNode TreeRoot { get; } = ShowRoomTreeNode.Build();
         public ShowRoomTreeNode DragDropTreeRoot { get; } = ShowRoomTreeNode.BuildDragDropDemo();
 
+        // Two independent source trees of the same shape - one rendered Forward, one Reversed -
+        // so we can eyeball the layers-panel ordering and confirm drag-drop InsertIndex stays source-space.
+        public ShowRoomTreeNode SiblingOrderForwardRoot { get; } = ShowRoomTreeNode.BuildSiblingOrderDemo();
+        public ShowRoomTreeNode SiblingOrderReversedRoot { get; } = ShowRoomTreeNode.BuildSiblingOrderDemo();
+
+        private void SiblingOrderTree_OnReorder (object sender, FlatTreeReorderEventArgs e)
+        {
+            var control = sender as AJut.UX.Controls.FlatTreeListControl;
+            string parentName = e.TargetParent is ShowRoomTreeNode parent ? parent.NodeName : "(null)";
+            string items = string.Join(", ", e.Items.OfType<ShowRoomTreeNode>().Select(n => n.NodeName));
+            string line = $"[{DateTime.Now:HH:mm:ss}] -> '{parentName}' InsertIndex={e.InsertIndex} (source) | items=[{items}]" + Environment.NewLine;
+
+            TextBox log = control == this.SiblingOrderReversedTree
+                ? this.SiblingOrderReversedLog
+                : this.SiblingOrderForwardLog;
+            log.Text = line + log.Text;
+        }
+
         // ===========[ SetSelection sandbox scenario ]===========================
         // Exercises FlatTreeListControl.SetSelection on an Extended-mode tree.
         // Expected: all requested rows highlight (4px accent strip), and
@@ -574,6 +592,27 @@ namespace AJutShowRoomWinUI
             childB.AddItem("Grandchild B2");
 
             root.AddItem("Child C");
+            return root;
+        }
+
+        // Side-by-side Forward/Reversed comparison source. Names track source order (A0, A1, ...)
+        // so that the Reversed pane visually lists them highest-index-first at every level.
+        public static ShowRoomTreeNode BuildSiblingOrderDemo()
+        {
+            var root = new ShowRoomTreeNode("Root");
+            root.CanHaveChildren = true;
+
+            var a = root.AddItem("A");
+            a.AddItem("A0");
+            a.AddItem("A1");
+            a.AddItem("A2");
+
+            root.AddItem("B");
+
+            var c = root.AddItem("C");
+            c.AddItem("C0");
+            c.AddItem("C1");
+
             return root;
         }
 

--- a/sandbox/wpf/UI/Controls/FlatTreeListControlExample.xaml
+++ b/sandbox/wpf/UI/Controls/FlatTreeListControlExample.xaml
@@ -17,6 +17,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <StackPanel>
             <TextBlock TextWrapping="WrapWithOverflow">
@@ -50,5 +51,73 @@
             </ajut:FlatTreeListControl.Resources>
         </ajut:FlatTreeListControl>
         <Button Grid.Row="2" Content="Code Example ↑" HorizontalAlignment="Center" Click="PopupCodeExample_OnClick" Margin="0,0,0,10"/>
+
+        <!-- Sibling Order demo: same source shape rendered Forward (left) and Reversed (right).
+             Drag-drop log proves InsertIndex stays source-space regardless of visual order. -->
+        <Expander Grid.Row="3" Header="SiblingDisplayOrder demo (layers-panel style)" Margin="0,0,0,10">
+            <Grid Margin="0,8,0,0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="Auto"/>
+                    <RowDefinition Height="220"/>
+                    <RowDefinition Height="100"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*"/>
+                    <ColumnDefinition Width="8"/>
+                    <ColumnDefinition Width="*"/>
+                </Grid.ColumnDefinitions>
+
+                <TextBlock Grid.Row="0" Grid.ColumnSpan="3"
+                           Text="Two trees over the same source. Left renders Forward, right renders Reversed - every parent iterates highest-source-index-first. Drag items in either tree and check the log: TargetParent + InsertIndex are source-space, identical regardless of visual order."
+                           TextWrapping="Wrap" Margin="0,0,0,6"/>
+
+                <TextBlock Grid.Row="1" Grid.Column="0" Text="Forward" FontWeight="Bold" Margin="0,0,0,4"/>
+                <TextBlock Grid.Row="1" Grid.Column="2" Text="Reversed (layers-panel)" FontWeight="Bold" Margin="0,0,0,4"/>
+
+                <ajut:FlatTreeListControl Grid.Row="2" Grid.Column="0"
+                                          x:Name="SiblingOrderForwardTree"
+                                          Root="{Binding ElementName=Self, Path=SiblingOrderForwardRoot}"
+                                          TreeDepthIndentSize="10" BorderThickness="1"
+                                          StartItemsExpanded="True"
+                                          IsDragDropReorderEnabled="True"
+                                          SelectionMode="Extended"
+                                          SiblingDisplayOrder="Forward"
+                                          DragDropReorderRequested="SiblingOrderTree_OnReorder">
+                    <ajut:FlatTreeListControl.Resources>
+                        <DataTemplate DataType="{x:Type local:TestTreeItem}">
+                            <TextBlock Text="{Binding Title}"/>
+                        </DataTemplate>
+                    </ajut:FlatTreeListControl.Resources>
+                </ajut:FlatTreeListControl>
+
+                <ajut:FlatTreeListControl Grid.Row="2" Grid.Column="2"
+                                          x:Name="SiblingOrderReversedTree"
+                                          Root="{Binding ElementName=Self, Path=SiblingOrderReversedRoot}"
+                                          TreeDepthIndentSize="10" BorderThickness="1"
+                                          StartItemsExpanded="True"
+                                          IsDragDropReorderEnabled="True"
+                                          SelectionMode="Extended"
+                                          SiblingDisplayOrder="Reversed"
+                                          DragDropReorderRequested="SiblingOrderTree_OnReorder">
+                    <ajut:FlatTreeListControl.Resources>
+                        <DataTemplate DataType="{x:Type local:TestTreeItem}">
+                            <TextBlock Text="{Binding Title}"/>
+                        </DataTemplate>
+                    </ajut:FlatTreeListControl.Resources>
+                </ajut:FlatTreeListControl>
+
+                <TextBox Grid.Row="3" Grid.Column="0"
+                         x:Name="SiblingOrderForwardLog"
+                         IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                         FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
+                         VerticalScrollBarVisibility="Auto"/>
+                <TextBox Grid.Row="3" Grid.Column="2"
+                         x:Name="SiblingOrderReversedLog"
+                         IsReadOnly="True" AcceptsReturn="True" TextWrapping="Wrap"
+                         FontFamily="Consolas" FontSize="11" Margin="0,4,0,0"
+                         VerticalScrollBarVisibility="Auto"/>
+            </Grid>
+        </Expander>
     </Grid>
 </UserControl>

--- a/sandbox/wpf/UI/Controls/FlatTreeListControlExample.xaml.cs
+++ b/sandbox/wpf/UI/Controls/FlatTreeListControlExample.xaml.cs
@@ -1,6 +1,8 @@
 ﻿namespace TheAJutShowRoom.UI.Controls
 {
+    using System;
     using System.Diagnostics;
+    using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
     using AJut.Storage;
@@ -26,6 +28,12 @@
                     var m = _SetExpanded(c.Add());
                         var n = m.Add();
             this.Root = a;
+
+            // Independent source trees for the SiblingDisplayOrder side-by-side demo. Names track
+            // source order so the Reversed pane visually lists them highest-index-first per level.
+            this.SiblingOrderForwardRoot = BuildSiblingOrderDemoRoot();
+            this.SiblingOrderReversedRoot = BuildSiblingOrderDemoRoot();
+
             this.InitializeComponent();
 
             TestTreeItem _SetExpanded (TestTreeItem item)
@@ -54,6 +62,55 @@
         {
             get => (TestTreeItem)this.GetValue(RootProperty);
             set => this.SetValue(RootProperty, value);
+        }
+
+        public static readonly DependencyProperty SiblingOrderForwardRootProperty = DPUtils.Register(_ => _.SiblingOrderForwardRoot);
+        public TestTreeItem SiblingOrderForwardRoot
+        {
+            get => (TestTreeItem)this.GetValue(SiblingOrderForwardRootProperty);
+            set => this.SetValue(SiblingOrderForwardRootProperty, value);
+        }
+
+        public static readonly DependencyProperty SiblingOrderReversedRootProperty = DPUtils.Register(_ => _.SiblingOrderReversedRoot);
+        public TestTreeItem SiblingOrderReversedRoot
+        {
+            get => (TestTreeItem)this.GetValue(SiblingOrderReversedRootProperty);
+            set => this.SetValue(SiblingOrderReversedRootProperty, value);
+        }
+
+        private static TestTreeItem BuildSiblingOrderDemoRoot ()
+        {
+            // Root with three children A/B/C; A and C each have their own children.
+            // Same shape that drives the WinUI3 demo so behavior is directly comparable.
+            var root = new TestTreeItem { Title = "Root" };
+
+            var a = root.Add();
+            a.Title = "A";
+            a.Add().Title = "A0";
+            a.Add().Title = "A1";
+            a.Add().Title = "A2";
+
+            var b = root.Add();
+            b.Title = "B";
+
+            var c = root.Add();
+            c.Title = "C";
+            c.Add().Title = "C0";
+            c.Add().Title = "C1";
+
+            return root;
+        }
+
+        private void SiblingOrderTree_OnReorder (object sender, FlatTreeReorderEventArgs e)
+        {
+            string parentName = e.TargetParent is TestTreeItem parent ? parent.Title : "(null)";
+            string items = string.Join(", ", e.Items.OfType<TestTreeItem>().Select(n => n.Title));
+            string line = $"[{DateTime.Now:HH:mm:ss}] -> '{parentName}' InsertIndex={e.InsertIndex} (source) | items=[{items}]" + Environment.NewLine;
+
+            TextBox log = ReferenceEquals(sender, this.SiblingOrderReversedTree)
+                ? this.SiblingOrderReversedLog
+                : this.SiblingOrderForwardLog;
+            log.Text = line + log.Text;
         }
 
         private void PopupCodeExample_OnClick (object sender, RoutedEventArgs e)

--- a/test/AJut.Core.Tests/TreeTraversalTesting.cs
+++ b/test/AJut.Core.Tests/TreeTraversalTesting.cs
@@ -238,6 +238,42 @@
             }
         }
 
+        // Per-level reversed sibling iteration: forward DFS through children, but at every parent
+        // we iterate siblings highest-source-index-first. Orthogonal to flow direction.
+        private static readonly string[] kReversedSiblingDFS_Order =
+        {
+            "root", "c", "c.a", "c.a.b", "c.a.a", "b", "a", "a.c", "a.b", "a.b.c", "a.b.b", "a.b.a", "a.a",
+        };
+
+        [TestMethod]
+        public void TreeTraversal_SiblingOrderReversed_DFS_WalksHighestIndexFirstAtEachLevel()
+        {
+            var parameters = new TreeTraversalParameters<TestTreePart>(
+                root,
+                eTraversalFlowDirection.ThroughChildren,
+                eTraversalStrategy.DepthFirst)
+            {
+                SiblingOrder = eSiblingOrder.Reversed,
+            };
+
+            string[] visited = TreeTraversal<TestTreePart>.All(root, parameters).Select(n => n.Value).ToArray();
+            CollectionAssert.AreEqual(kReversedSiblingDFS_Order, visited);
+        }
+
+        [TestMethod]
+        public void TreeTraversal_SiblingOrderForward_DefaultMatchesExistingDFS()
+        {
+            // Make sure passing parameters with default SiblingOrder doesn't regress the existing
+            // forward-DFS sequence (kDFS_Order).
+            var parameters = new TreeTraversalParameters<TestTreePart>(
+                root,
+                eTraversalFlowDirection.ThroughChildren,
+                eTraversalStrategy.DepthFirst);
+
+            string[] visited = TreeTraversal<TestTreePart>.All(root, parameters).Select(n => n.Value).ToArray();
+            CollectionAssert.AreEqual(kDFS_Order, visited);
+        }
+
         [TestMethod]
         public void TreeTraversal_ReverseIteration_DFS_Works()
         {


### PR DESCRIPTION
For a tool using ajut, I have a situation where a tree like this:
```
Root
 | -> A
        | -> A0
        | -> A1
 | -> B
 | -> C
         | -> C0
         | -> C1
         | -> C2
```

then the flat tree list control can show it, no problem! However, if I want to make a situation where the lowest tree element overrides (or in my case, overlays) the previous ones, then visually the two things don't line up - where you need to be lower down on the tree list control, to be "higher up" in z order. This change is all about making the tree traversal possible, and then hooking it up into flat tree list so I can have this:
```
Root
 | -> C
         | -> C2
         | -> C1
         | -> C0
 | -> B
 | -> A
        | -> A1
        | -> A0
```