### PR TITLE
Pg member ordering

### DIFF
--- a/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
+++ b/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
@@ -18,7 +18,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsPackageType>None</WindowsPackageType>
-    <Version>1.1.5.122</Version>
+    <Version>1.1.6.124</Version>
     <!-- =========[ NuGet packaging - ensure XBF + PRI resources are included ]======== -->
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
+++ b/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
@@ -15,7 +15,7 @@
     <PackageTags>c#;dotnet;wpf;theming;controls;converters;app;utilities</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.5.4.122</Version>
+    <Version>1.5.5.124</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />

--- a/libs/AJut.UX/AJut.UX.csproj
+++ b/libs/AJut.UX/AJut.UX.csproj
@@ -14,7 +14,7 @@
     <PackageTags>c#;dotnet;theming;controls;converters;app;utilities</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.4.122</Version>
+    <Version>1.1.5.124</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\ajut-logo-128.png">

--- a/libs/AJut.UX/PropertyInteraction/PropertyEditTarget.cs
+++ b/libs/AJut.UX/PropertyInteraction/PropertyEditTarget.cs
@@ -169,11 +169,19 @@ namespace AJut.UX.PropertyInteraction
         public string GroupId { get; set; }
 
         /// <summary>
-        /// Optional explicit ordering pulled from [PGMemberOrder]. When set, this target sorts ahead
-        /// of untagged targets in the property grid (lowest value first); when null, natural emission
-        /// order is used. Set for both property rows and [PGButton] rows so the two interleave.
+        /// Optional explicit ordering pulled from [PGMemberOrder] (or core [MemberOrder] as a fallback).
+        /// The grid sorts rows by this value flexbox-style: a row with no value is treated as order 0,
+        /// so negative values pull ahead of unordered rows and positive values fall behind them. Set for
+        /// both property rows and [PGButton] rows so the two interleave on one axis.
         /// </summary>
         public int? MemberSortOrder { get; set; }
+
+        /// <summary>
+        /// The natural (declaration / emission) position of this row, stamped in one pass as targets are
+        /// collected. Used as the ordering tiebreaker so unordered rows (effective order 0) and rows that
+        /// share an order value fall back to declaration order rather than an arbitrary one.
+        /// </summary>
+        public int NaturalOrder { get; set; }
 
         /// <summary>
         /// The object on which ShowIf/HideIf condition members are evaluated.
@@ -457,7 +465,10 @@ namespace AJut.UX.PropertyInteraction
                     Editor = editorKey,
                     EditContext = editContext,
                     AdditionalEvalTargets = aliases,
-                    MemberSortOrder = TypeMetadataExtensionRegistrar.GetAttribute<PGMemberOrderAttribute>(prop)?.Order,
+                    // [PGMemberOrder] wins; fall back to core [MemberOrder] so properties positioned
+                    // with [MemberOrder] share one ordering axis with [PGMemberOrder] buttons.
+                    MemberSortOrder = TypeMetadataExtensionRegistrar.GetAttribute<PGMemberOrderAttribute>(prop)?.Order
+                        ?? TypeMetadataExtensionRegistrar.GetAttribute<MemberOrderAttribute>(prop)?.Order,
                 };
 
                 // 3b. Complete deferred coerce holder and coercion delegate assignment

--- a/libs/AJut.UX/PropertyInteraction/PropertyGridManager.cs
+++ b/libs/AJut.UX/PropertyInteraction/PropertyGridManager.cs
@@ -117,6 +117,10 @@ namespace AJut.UX.PropertyInteraction
             var root = new PropertyEditTarget("$_root_", () => null, null);
             var editTargets = new Dictionary<int, PropertyEditTarget>();
 
+            // First-pass declaration counter: every target gets a NaturalOrder as it is collected, so
+            // ordering has one cogent tiebreaker instead of relying on dictionary enumeration order.
+            int naturalOrderCounter = 0;
+
             // Materialize source items so we can iterate twice (targets + conditions)
             var sourceList = new List<object>();
             foreach (object item in sourceItems)
@@ -167,16 +171,14 @@ namespace AJut.UX.PropertyInteraction
                 }
             }
 
-            // ------ Interleave property and button rows by [PGMemberOrder]
-            // Tagged targets (properties or [PGButton] methods) sort ahead of untagged ones by
-            // ascending order value; untagged targets keep their natural emission order (properties
-            // first in their resolved order, then buttons). OrderBy is a stable sort, so with no
-            // [PGMemberOrder] anywhere this is identical to the prior straight emission order.
+            // ------ Interleave rows by order, flexbox-style.
+            // Every row's effective order is its [PGMemberOrder]/[MemberOrder] value, or 0 when it has
+            // none. Rows sort by that value and tie-break on NaturalOrder (declaration order). So an
+            // unordered row sits at the 0 baseline - negative orders pull ahead of it, positive orders
+            // fall behind it - and rows interleave by number instead of "all ordered, then all unordered".
             var orderedTargets = editTargets.Values
-                .Select((target, naturalIndex) => (target, naturalIndex))
-                .OrderBy(x => x.target.MemberSortOrder.HasValue ? 0 : 1)
-                .ThenBy(x => x.target.MemberSortOrder ?? x.naturalIndex)
-                .Select(x => x.target)
+                .OrderBy(t => t.MemberSortOrder ?? 0)
+                .ThenBy(t => t.NaturalOrder)
                 .ToList();
 
             // ------ Group post-processing: collect targets with matching GroupId
@@ -264,6 +266,7 @@ namespace AJut.UX.PropertyInteraction
                     return;
                 }
 
+                _target.NaturalOrder = naturalOrderCounter++;
                 editTargets.Add(_id, _target);
             }
         }

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -760,6 +760,12 @@
                                     <Button x:Name="PG_DelegatedButtonsButton" Content="Delegated Buttons (delegating edit manager)"
                                             Click="PGSource_OnDelegatedButtonsClicked"
                                             ToolTipService.ToolTip="Source is a delegating edit manager wrapping an inner object that has a [PGButton]. The manager surfaces the inner button itself, so it shows in the grid."/>
+                                    <Button x:Name="PG_MixedOrderButton" Content="Mixed Order ([MemberOrder] props + [PGMemberOrder] button)"
+                                            Click="PGSource_OnMixedOrderClicked"
+                                            ToolTipService.ToolTip="Properties use core [MemberOrder] (1,10,11,20,21); the button uses [PGMemberOrder(22)]. With the fold, the button slots in after Height instead of floating to the top."/>
+                                    <Button x:Name="PG_ManualMixedOrderButton" Content="Mixed Order (manual PET construction)"
+                                            Click="PGSource_OnManualMixedOrderClicked"
+                                            ToolTipService.ToolTip="Same mix built by hand (no attributes) - the manager positions every row, properties and button, by setting MemberSortOrder directly."/>
                                     <Button Content="Set Elevated Values" Click="PGSource_OnSetElevatedClicked"
                                             ToolTipService.ToolTip="Sets elevated property values externally - tests RecacheEditValue cascade"/>
                                     <Button x:Name="PG_WrappedMatrixButton" Content="Wrapped Mode Matrix (PGShowIf repro)"

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -320,6 +320,11 @@ namespace AJutShowRoomWinUI
         // itself, since the grid only auto-harvests buttons off the source it's handed. See
         // ButtonDelegationDemo.cs.
         private readonly ButtonDelegationEditManager m_delegatedButtonsObj = new ButtonDelegationEditManager();
+        // Mixed ordering: [MemberOrder] properties + a [PGMemberOrder] button - exposes that the two
+        // attributes don't sort on a shared axis (see MixedOrderButtonSource).
+        private readonly MixedOrderButtonSource m_mixedOrderObj = new MixedOrderButtonSource();
+        // Same mix, but built by hand (manual PETs) - positions every row via MemberSortOrder.
+        private readonly ManualMixedOrderManager m_manualMixedOrderObj = new ManualMixedOrderManager();
         private readonly WrappedModeMatrixSource m_wrappedMatrixObj = new WrappedModeMatrixSource();
         private object m_currentPGTestObj;
 
@@ -335,6 +340,8 @@ namespace AJutShowRoomWinUI
         private void PGSource_OnComplexClicked (object sender, RoutedEventArgs e) => this.SetPGSource(m_complexObj);
         private void PGSource_OnComplexBClicked (object sender, RoutedEventArgs e) => this.SetPGSource(m_complexObj2);
         private void PGSource_OnDelegatedButtonsClicked (object sender, RoutedEventArgs e) => this.SetPGSource(m_delegatedButtonsObj);
+        private void PGSource_OnMixedOrderClicked (object sender, RoutedEventArgs e) => this.SetPGSource(m_mixedOrderObj);
+        private void PGSource_OnManualMixedOrderClicked (object sender, RoutedEventArgs e) => this.SetPGSource(m_manualMixedOrderObj);
         private void PGSource_OnWrappedMatrixClicked (object sender, RoutedEventArgs e)
         {
             this.SetPGSource(m_wrappedMatrixObj);
@@ -832,13 +839,15 @@ namespace AJutShowRoomWinUI
         // ------ PGMemberOrder demo ------
         // Declared out of source order on purpose but tagged with [PGMemberOrder]. They render inside
         // the "PGMemberOrder Demo" group in order-value sequence (10, the button at 15, then 20),
-        // proving a button interleaves between properties. The labels call out each expected slot.
+        // proving a button interleaves between properties. The labels call out each expected slot. The
+        // group's values are all positive, so it sorts after the unordered rows (the 0 baseline).
         [PGMemberOrder(20)]
         [PGGroup("PGMemberOrder Demo")]
         [PGLabel("Third (order=20)")]
         public string MemberOrderThird { get; set; } = "third";
 
         [PGMemberOrder(15)]
+        [PGGroup("PGMemberOrder Demo")]
         [PGButton("Button (order=15)")]
         public void MemberOrderDemoButton ()
         {
@@ -1036,6 +1045,76 @@ namespace AJutShowRoomWinUI
     {
         public float X { get; set; } = 777f;
         public float Y { get; set; } = 888f;
+    }
+
+    // ===========[ MixedOrder - [MemberOrder] props + [PGMemberOrder] button ]=======
+    // Reproduces the element-editing case: properties positioned with core [MemberOrder] across a
+    // base/derived split, plus a button positioned with [PGMemberOrder]. The numbers read as one
+    // sequence (1, 10, 11, 20, 21, 22) and the grid now sorts them on one axis, so the button slots
+    // in after Height(21). Every row here is explicitly ordered, so there is no 0-baseline gap.
+    public class MixedOrderBase : NotifyPropertyChanged
+    {
+        [PGEditor("Text")]
+        [MemberOrder(1)]
+        public string Name { get; set; } = "base name";
+    }
+
+    public class MixedOrderButtonSource : MixedOrderBase
+    {
+        [PGEditor("Text")]
+        [MemberOrder(10)]
+        public string SourcePath { get; set; } = "cfr://example";
+
+        [PGEditor("AutoEnum")]
+        [MemberOrder(11)]
+        public eEditorMode Mode { get; set; } = eEditorMode.Text;
+
+        [PGEditor("Single")]
+        [MemberOrder(20)]
+        public float Width { get; set; } = 5f;
+
+        [PGEditor("Single")]
+        [MemberOrder(21)]
+        public float Height { get; set; } = 5f;
+
+        // Slots in after Height (21), since all rows share one ordering axis.
+        [PGButton("Reset Size From Source")]
+        [PGMemberOrder(22)]
+        public void ResetSize ()
+        {
+            this.Width = 5f;
+            this.Height = 5f;
+        }
+    }
+
+    // Manual-PET equivalent of MixedOrderButtonSource: a hand-assembled edit manager. There are no
+    // attributes to read here, so it positions every row - properties and the button - by setting
+    // MemberSortOrder directly. CreateButton makes the button row; MemberSortOrder slots it after Height.
+    public class ManualMixedOrderManager : IPropertyEditManager
+    {
+        private readonly MixedOrderButtonSource m_data = new MixedOrderButtonSource();
+
+        public IEnumerable<PropertyEditTarget> GenerateEditTargets ()
+        {
+            yield return MakeRow("Name", "Text", () => m_data.Name, v => m_data.Name = v as string ?? "", 1);
+            yield return MakeRow("SourcePath", "Text", () => m_data.SourcePath, v => m_data.SourcePath = v as string ?? "", 10);
+            yield return MakeRow("Width", "Single", () => m_data.Width, v => m_data.Width = System.Convert.ToSingle(v), 20);
+            yield return MakeRow("Height", "Single", () => m_data.Height, v => m_data.Height = System.Convert.ToSingle(v), 21);
+
+            var button = PropertyEditTarget.CreateButton("Reset Size From Source", () => m_data.ResetSize());
+            button.MemberSortOrder = 22;
+            yield return button;
+        }
+
+        private static PropertyEditTarget MakeRow (string path, string editor, PropertyEditTarget.GetValue get, PropertyEditTarget.SetValue set, int order)
+        {
+            return new PropertyEditTarget(path, get, set)
+            {
+                DisplayName = path,
+                Editor = editor,
+                MemberSortOrder = order,
+            };
+        }
     }
 
     // ===========[ ShowRoomPanelState - DockZone save/load state bag ]===============

--- a/test/AJut.UX.Tests/PropertyGridTests.cs
+++ b/test/AJut.UX.Tests/PropertyGridTests.cs
@@ -9,6 +9,7 @@ namespace AJut.UX.Tests
     using System.Windows.Input;
     using AJut.Storage;
     using AJut.Tree;
+    using AJut.TypeManagement;
     using AJut.UX.PropertyInteraction;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -99,6 +100,10 @@ namespace AJut.UX.Tests
     // untagged property to prove buttons interleave with properties rather than trailing at the end.
     public class MemberOrderTestSource
     {
+        [PGMemberOrder(-5)]
+        [PGEditor("Text")]
+        public string PinnedFirst { get; set; } = "pinned";
+
         [PGEditor("Text")]
         public string Untagged { get; set; } = "u";
 
@@ -171,6 +176,35 @@ namespace AJut.UX.Tests
                 yield return button;
             }
         }
+    }
+
+    // Mixed ordering across a base/derived split: properties positioned with core [MemberOrder] plus
+    // a [PGMemberOrder] button. With [MemberOrder] folded into the grid's sort axis, the button slots
+    // in by value instead of floating to the top.
+    public class MemberOrderFoldBase : NotifyPropertyChanged
+    {
+        [PGEditor("Text")]
+        [MemberOrder(1)]
+        public string Name { get; set; } = "n";
+    }
+
+    public class MemberOrderFoldSource : MemberOrderFoldBase
+    {
+        [PGEditor("Text")]
+        [MemberOrder(10)]
+        public string SourcePath { get; set; } = "p";
+
+        [PGEditor("Single")]
+        [MemberOrder(20)]
+        public float Width { get; set; } = 5f;
+
+        [PGEditor("Single")]
+        [MemberOrder(21)]
+        public float Height { get; set; } = 5f;
+
+        [PGButton("Reset")]
+        [PGMemberOrder(22)]
+        public void Reset () { }
     }
 
     public class GroupedShowIfTestSource : NotifyPropertyChanged
@@ -1388,22 +1422,23 @@ namespace AJut.UX.Tests
                 .Select(t => t.PropertyPathTarget)
                 .ToList();
 
-            // Tagged members lead in ascending order value (First=1, MiddleButton=5, Last=10),
-            // and the untagged property trails after all tagged members.
+            // Flexbox order: the negative-ordered row pulls ahead of the unordered 0 baseline, positive
+            // orders fall behind it, and the button (5) interleaves between First (1) and Last (10).
             CollectionAssert.AreEqual(
                 new[]
                 {
+                    nameof(MemberOrderTestSource.PinnedFirst),
+                    nameof(MemberOrderTestSource.Untagged),
                     nameof(MemberOrderTestSource.First),
                     nameof(MemberOrderTestSource.MiddleButton),
                     nameof(MemberOrderTestSource.Last),
-                    nameof(MemberOrderTestSource.Untagged),
                 },
                 topLevel
             );
         }
 
         [TestMethod]
-        public void MemberOrder_PositionsButtonAheadOfUntaggedProperty ()
+        public void MemberOrder_UnorderedSitsAtZeroBaseline ()
         {
             var source = new MemberOrderTestSource();
             var pg = new SimpleTestPropertyGrid { SingleItemSource = source };
@@ -1412,13 +1447,46 @@ namespace AJut.UX.Tests
             manager.RebuildEditTargets();
 
             var topLevel = manager.RootNode.Children.OfType<PropertyEditTarget>().ToList();
-            int buttonIndex = topLevel.FindIndex(t => t.Editor == "Button");
+            int pinnedIndex = topLevel.FindIndex(t => t.PropertyPathTarget == nameof(MemberOrderTestSource.PinnedFirst));
             int untaggedIndex = topLevel.FindIndex(t => t.PropertyPathTarget == nameof(MemberOrderTestSource.Untagged));
+            int firstIndex = topLevel.FindIndex(t => t.PropertyPathTarget == nameof(MemberOrderTestSource.First));
 
-            Assert.IsTrue(buttonIndex >= 0, "The button row should be present");
             Assert.IsTrue(
-                buttonIndex < untaggedIndex,
-                "A [PGMemberOrder]-tagged button should sort ahead of an untagged property instead of trailing at the end"
+                pinnedIndex < untaggedIndex,
+                "A negative [PGMemberOrder] should pull ahead of an unordered row (which sits at the 0 baseline)"
+            );
+            Assert.IsTrue(
+                untaggedIndex < firstIndex,
+                "An unordered row (effective order 0) should precede a positively-ordered row instead of trailing after it"
+            );
+        }
+
+        [TestMethod]
+        public void MemberOrder_AndPGMemberOrder_ShareOneAxis ()
+        {
+            // [MemberOrder] properties and a [PGMemberOrder] button read as one number sequence
+            // (1, 10, 20, 21, 22). The button should slot in by value, not float to the top; and the
+            // consistent base/derived numbering keeps the base property first.
+            var source = new MemberOrderFoldSource();
+            var pg = new SimpleTestPropertyGrid { SingleItemSource = source };
+            var manager = new PropertyGridManager(pg);
+
+            manager.RebuildEditTargets();
+
+            var topLevel = manager.RootNode.Children.OfType<PropertyEditTarget>()
+                .Select(t => t.PropertyPathTarget)
+                .ToList();
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    nameof(MemberOrderFoldBase.Name),
+                    nameof(MemberOrderFoldSource.SourcePath),
+                    nameof(MemberOrderFoldSource.Width),
+                    nameof(MemberOrderFoldSource.Height),
+                    "Reset",
+                },
+                topLevel
             );
         }
 


### PR DESCRIPTION
Was unhappy with how member ordering works. Now members are at 0 by default, and any value in member order will put them lower, or -1 to put before the default set. An attempt to make original order preserved as well.