### PR TITLE
CS selection handling (property grid + toggle strip) / memory leak fix

### DIFF
--- a/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
+++ b/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
@@ -18,7 +18,7 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <EnableMsixTooling>true</EnableMsixTooling>
     <WindowsPackageType>None</WindowsPackageType>
-    <Version>1.1.7.126</Version>
+    <Version>1.1.8.127</Version>
     <!-- =========[ NuGet packaging - ensure XBF + PRI resources are included ]======== -->
     <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/libs/AJut.UX.WinUI3/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.WinUI3/Controls/FlatTreeListControl.cs
@@ -482,20 +482,30 @@ namespace AJut.UX.Controls
 
             FlatTreeItem[] previous = m_selectedItems.ToArray();
 
+            // In Single/None modes only the first requested item is honored.
+            bool isMulti = (this.SelectionMode != eFlatTreeSelectionMode.Single
+                            && this.SelectionMode != eFlatTreeSelectionMode.None);
+
             m_blockingReentrancy = true;
             try
             {
-                this.PART_ListView.SelectedItems.Clear();
+                // WinUI3 throws a COMException if ListView.SelectedItems is mutated (Clear/Add) while
+                // SelectionMode is Single or None - there the selection runs through SelectedItem instead.
+                // Only touch SelectedItems in the multi-select modes.
+                if (isMulti)
+                {
+                    this.PART_ListView.SelectedItems.Clear();
+                }
+                else
+                {
+                    this.PART_ListView.SelectedItem = null;
+                }
 
                 foreach (FlatTreeItem stale in previous)
                 {
                     stale.IsSelected = false;
                 }
                 m_selectedItems.Clear();
-
-                // In Single/None modes only the first requested item is honored.
-                bool isMulti = (this.SelectionMode != eFlatTreeSelectionMode.Single
-                                && this.SelectionMode != eFlatTreeSelectionMode.None);
 
                 FlatTreeItem primary = null;
                 if (isMulti)
@@ -554,11 +564,24 @@ namespace AJut.UX.Controls
                 return null;
             }
 
-            foreach (FlatTreeItem item in TreeTraversal<FlatTreeItem>.All(m_store.RootNode))
+            return _FindItemForSource(m_store.RootNode, source);
+        }
+
+        // Recurse via AllChildren (visible + collapsed) rather than TreeTraversal so the search reaches
+        // rows parked inside collapsed parents - which is exactly what programmatic selection must expand to.
+        private static FlatTreeItem _FindItemForSource (FlatTreeItem node, IObservableTreeNode source)
+        {
+            if (node.Source == source)
             {
-                if (item.Source == source)
+                return node;
+            }
+
+            foreach (FlatTreeItem child in node.AllChildren)
+            {
+                FlatTreeItem found = _FindItemForSource(child, source);
+                if (found != null)
                 {
-                    return item;
+                    return found;
                 }
             }
 
@@ -599,10 +622,27 @@ namespace AJut.UX.Controls
                 }
             }
 
-            this.SetSelection(new[] { item });
-            if (scrollIntoView)
+            // Defer the select + scroll. Expanding a collapsed ancestor above reveals rows whose
+            // containers aren't realized until the next layout pass, so selecting / scrolling in the
+            // same synchronous beat silently no-ops. Posting to the dispatcher lets layout catch up
+            // first, and also decouples this from callers that invoke it from inside a pointer/input event.
+            void SelectAndScroll ()
             {
-                this.ScrollIntoView(item);
+                this.SetSelection(new[] { item });
+                if (scrollIntoView)
+                {
+                    this.ScrollIntoView(item);
+                }
+            }
+
+            var dispatcher = this.DispatcherQueue;
+            if (dispatcher != null)
+            {
+                dispatcher.TryEnqueue(SelectAndScroll);
+            }
+            else
+            {
+                SelectAndScroll();
             }
 
             return true;

--- a/libs/AJut.UX.WinUI3/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.WinUI3/Controls/FlatTreeListControl.cs
@@ -543,6 +543,71 @@ namespace AJut.UX.Controls
             }
         }
 
+        /// <summary>
+        /// Finds the row (visible or collapsed) that wraps the given source node, or null when no row
+        /// currently represents it. Searches the full tree, not just the realized/expanded rows.
+        /// </summary>
+        public FlatTreeItem FindItemForSource (IObservableTreeNode source)
+        {
+            if (source == null || m_store.RootNode == null)
+            {
+                return null;
+            }
+
+            foreach (FlatTreeItem item in TreeTraversal<FlatTreeItem>.All(m_store.RootNode))
+            {
+                if (item.Source == source)
+                {
+                    return item;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Selects the row wrapping the given source node, expanding any collapsed ancestors first so the
+        /// row is realized, and optionally scrolling it into view. Returns false when no row matches the
+        /// source or the control isn't ready to take a selection yet.
+        /// </summary>
+        public bool TrySelectItemForSource (IObservableTreeNode source, bool scrollIntoView = true)
+        {
+            if (this.PART_ListView == null)
+            {
+                return false;
+            }
+
+            FlatTreeItem item = this.FindItemForSource(source);
+            if (item == null)
+            {
+                return false;
+            }
+
+            // Expand collapsed ancestors top-down so the target row moves out of its parents'
+            // hidden-children lists and into the visible store before we select / scroll to it.
+            var ancestry = new List<FlatTreeItem>();
+            for (FlatTreeItem ancestor = item.Parent; ancestor != null; ancestor = ancestor.Parent)
+            {
+                ancestry.Add(ancestor);
+            }
+
+            for (int i = ancestry.Count - 1; i >= 0; --i)
+            {
+                if (ancestry[i].IsExpandable && !ancestry[i].IsExpanded)
+                {
+                    ancestry[i].IsExpanded = true;
+                }
+            }
+
+            this.SetSelection(new[] { item });
+            if (scrollIntoView)
+            {
+                this.ScrollIntoView(item);
+            }
+
+            return true;
+        }
+
         // ===========[ ListView event handlers ]==================================
         private void ListView_OnSelectionChanged (object sender, SelectionChangedEventArgs e)
         {

--- a/libs/AJut.UX.WinUI3/Controls/PropertyGrid.cs
+++ b/libs/AJut.UX.WinUI3/Controls/PropertyGrid.cs
@@ -34,6 +34,11 @@ namespace AJut.UX.Controls
         private readonly PropertyGridManager m_manager;
         private FlatTreeListControl PART_TreeList;
 
+        // Last source object reported through SelectedSourceObjectChanged. Held so we only raise that
+        // event when the resolved element actually changes - not when selection moves between two rows
+        // inside the same element's subtree.
+        private object m_lastSelectedSourceObject;
+
         // ===========[ Construction ]=============================================
         public PropertyGrid ()
         {
@@ -43,6 +48,16 @@ namespace AJut.UX.Controls
 
         public void Dispose ()
         {
+            if (this.PART_TreeList != null)
+            {
+                this.PART_TreeList.SelectionChanged -= this.OnTreeListSelectionChanged;
+                this.PART_TreeList.DragDropReorderRequested -= this.OnDragDropReorderRequested;
+            }
+
+            // Drop the per-target subscriptions and each target's elevated INPC hooks while the
+            // tree is still walkable. m_manager.Dispose() only clears collections; without this
+            // those subscriptions (and the whole source graph they reach) outlive the grid.
+            this._TeardownTargetSubscriptions();
             m_manager.Dispose();
             this.SingleItemSource = null;
             this.ItemsSource = null;
@@ -268,6 +283,74 @@ namespace AJut.UX.Controls
         /// </summary>
         public event EventHandler PropertyTreeChanged;
 
+        /// <summary>
+        /// Fires whenever the selected row changes - by user click or programmatic selection. Read
+        /// <see cref="SelectedTarget"/> / <see cref="SelectedSourceObject"/> in the handler.
+        /// </summary>
+        public event EventHandler SelectedTargetChanged;
+
+        /// <summary>
+        /// Fires when the source object behind the selected row changes. Moving the selection between two
+        /// rows inside the same list element's subtree resolves to the same element, so this does NOT fire
+        /// in that case - only when the resolved <see cref="SelectedSourceObject"/> actually changes.
+        /// </summary>
+        public event EventHandler SelectedSourceObjectChanged;
+
+        // ===========[ Selection ]================================================
+        /// <summary>
+        /// The PropertyEditTarget behind the currently selected row, or null when nothing is selected.
+        /// Setting it selects that row (expanding any collapsed ancestors) and scrolls it into view; set
+        /// to null to clear the selection. Returns null until the template has been applied.
+        /// </summary>
+        public PropertyEditTarget SelectedTarget
+        {
+            get => this.PART_TreeList?.SelectedItem?.Source as PropertyEditTarget;
+            set
+            {
+                if (this.PART_TreeList == null)
+                {
+                    return;
+                }
+
+                if (value == null)
+                {
+                    this.PART_TreeList.SetSelection(null);
+                    return;
+                }
+
+                this.PART_TreeList.TrySelectItemForSource(value, scrollIntoView: true);
+            }
+        }
+
+        /// <summary>
+        /// The source object behind the selected row, resolved by walking up from the selected row to the
+        /// nearest list-element row and returning its element instance. Null when nothing is selected or
+        /// the selection sits outside any list element. Selecting any row inside an element's subtree
+        /// (the element row itself or any of its sub-property rows) resolves to that same element.
+        /// </summary>
+        public object SelectedSourceObject => _ResolveSourceObject(this.SelectedTarget);
+
+        /// <summary>
+        /// Selects the row representing <paramref name="sourceObject"/> (matched by reference), expanding
+        /// any collapsed ancestors and scrolling it into view. Returns false when no row represents the
+        /// instance. Only list-element rows carry a source object, so this targets list elements.
+        /// </summary>
+        public bool TrySelectSourceObject (object sourceObject)
+        {
+            if (sourceObject == null || this.PART_TreeList == null)
+            {
+                return false;
+            }
+
+            PropertyEditTarget match = this.FindTargetForSourceObject(sourceObject);
+            if (match == null)
+            {
+                return false;
+            }
+
+            return this.PART_TreeList.TrySelectItemForSource(match, scrollIntoView: true);
+        }
+
         // ===========[ Template application ]====================================
         protected override void OnApplyTemplate ()
         {
@@ -275,6 +358,7 @@ namespace AJut.UX.Controls
 
             if (this.PART_TreeList != null)
             {
+                this.PART_TreeList.SelectionChanged -= this.OnTreeListSelectionChanged;
                 this.PART_TreeList.DragDropReorderRequested -= this.OnDragDropReorderRequested;
             }
 
@@ -296,6 +380,9 @@ namespace AJut.UX.Controls
                 this.PART_TreeList.CanDragItem = _CanDragPropertyItem;
                 this.PART_TreeList.CanDropItem = _CanDropPropertyItem;
                 this.PART_TreeList.DragDropReorderRequested += this.OnDragDropReorderRequested;
+
+                this.PART_TreeList.SelectionChanged -= this.OnTreeListSelectionChanged;
+                this.PART_TreeList.SelectionChanged += this.OnTreeListSelectionChanged;
 
                 // Suppress list add/remove/reorder animations in the PropertyGrid
                 this.PART_TreeList.SuppressItemTransitions = true;
@@ -327,6 +414,7 @@ namespace AJut.UX.Controls
             }
             else
             {
+                this._TeardownTargetSubscriptions();
                 m_manager.Dispose();
                 this.PropertyTreeItems = null;
 
@@ -368,6 +456,7 @@ namespace AJut.UX.Controls
             }
             else
             {
+                this._TeardownTargetSubscriptions();
                 m_manager.Dispose();
                 this.PropertyTreeItems = null;
 
@@ -403,20 +492,7 @@ namespace AJut.UX.Controls
         private void RebuildEditTargets ()
         {
             // Unsubscribe from old tree (and hidden conditional targets) before rebuild.
-            if (m_manager.RootNode != null)
-            {
-                foreach (var target in _WalkAllTargets(m_manager.RootNode))
-                {
-                    target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
-                    target.Teardown();
-                }
-
-                foreach (var target in m_manager.HiddenConditionalTargets)
-                {
-                    target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
-                    target.Teardown();
-                }
-            }
+            this._TeardownTargetSubscriptions();
 
             m_manager.RebuildEditTargets();
 
@@ -488,6 +564,30 @@ namespace AJut.UX.Controls
             }
         }
 
+        // Drops every per-target PropertyChanged subscription and tears down each target's elevated
+        // sub-object INPC hooks. Walks the live tree plus the hidden-conditional targets (which are
+        // subscribed even while out of the tree). Called before every rebuild and on dispose / source
+        // clear so a torn-down grid does not leave subscriptions pinning the target/source graph.
+        private void _TeardownTargetSubscriptions ()
+        {
+            if (m_manager.RootNode == null)
+            {
+                return;
+            }
+
+            foreach (var target in _WalkAllTargets(m_manager.RootNode))
+            {
+                target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
+                target.Teardown();
+            }
+
+            foreach (var target in m_manager.HiddenConditionalTargets)
+            {
+                target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
+                target.Teardown();
+            }
+        }
+
         private static IEnumerable<PropertyEditTarget> _WalkAllTargets (IObservableTreeNode node)
         {
             foreach (var child in node.Children)
@@ -506,6 +606,53 @@ namespace AJut.UX.Controls
                     }
                 }
             }
+        }
+
+        // ===========[ Selection handling ]=======================================
+        private void OnTreeListSelectionChanged (object sender, SelectionChange<FlatTreeItem> e)
+        {
+            this.SelectedTargetChanged?.Invoke(this, EventArgs.Empty);
+
+            object newSource = this.SelectedSourceObject;
+            if (!ReferenceEquals(newSource, m_lastSelectedSourceObject))
+            {
+                m_lastSelectedSourceObject = newSource;
+                this.SelectedSourceObjectChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private PropertyEditTarget FindTargetForSourceObject (object sourceObject)
+        {
+            if (m_manager.RootNode == null)
+            {
+                return null;
+            }
+
+            foreach (PropertyEditTarget target in _WalkAllTargets(m_manager.RootNode))
+            {
+                if (ReferenceEquals(target.SourceObject, sourceObject))
+                {
+                    return target;
+                }
+            }
+
+            return null;
+        }
+
+        // Walk up (including the row itself) to the nearest row that stands in for a source object - i.e.
+        // the nearest list-element ancestor - and return its element instance.
+        private static object _ResolveSourceObject (PropertyEditTarget target)
+        {
+            for (PropertyEditTarget cursor = target; cursor != null; cursor = cursor.Parent as PropertyEditTarget)
+            {
+                object source = cursor.SourceObject;
+                if (source != null)
+                {
+                    return source;
+                }
+            }
+
+            return null;
         }
 
         private void ApplyRowTemplate ()

--- a/libs/AJut.UX.WinUI3/Controls/PropertyGridItemRow.cs
+++ b/libs/AJut.UX.WinUI3/Controls/PropertyGridItemRow.cs
@@ -37,6 +37,7 @@ namespace AJut.UX.Controls
     [TemplatePart(Name = nameof(PART_LabelContent), Type = typeof(ContentControl))]
     [TemplatePart(Name = nameof(PART_SubtitleText), Type = typeof(TextBlock))]
     [TemplatePart(Name = nameof(PART_EditorContent), Type = typeof(ContentControl))]
+    [TemplatePart(Name = nameof(PART_ListElementHeader), Type = typeof(TextBlock))]
     [TemplatePart(Name = nameof(PART_DeleteButton), Type = typeof(Button))]
     public class PropertyGridItemRow : Control
     {
@@ -46,6 +47,10 @@ namespace AJut.UX.Controls
         // ===========[ Instance fields ]==========================================
         private FlatTreeItem m_flatTreeItem;
         private PropertyEditTarget m_editTarget;
+
+        // Bumped on every DataContext change so a deferred ApplyEditorContent callback can tell
+        // whether it is still the most recent one without capturing (and thus pinning) the target.
+        private int m_dataContextRevision;
 
         // ===========[ Construction ]=============================================
         public PropertyGridItemRow ()
@@ -60,6 +65,7 @@ namespace AJut.UX.Controls
         private ContentControl PART_LabelContent { get; set; }
         private TextBlock PART_SubtitleText { get; set; }
         private ContentControl PART_EditorContent { get; set; }
+        private TextBlock PART_ListElementHeader { get; set; }
         private Button PART_DeleteButton { get; set; }
 
         // ===========[ Dependency Properties ]====================================
@@ -137,6 +143,7 @@ namespace AJut.UX.Controls
             this.PART_LabelContent = this.GetTemplateChild(nameof(PART_LabelContent)) as ContentControl;
             this.PART_SubtitleText = this.GetTemplateChild(nameof(PART_SubtitleText)) as TextBlock;
             this.PART_EditorContent = this.GetTemplateChild(nameof(PART_EditorContent)) as ContentControl;
+            this.PART_ListElementHeader = this.GetTemplateChild(nameof(PART_ListElementHeader)) as TextBlock;
             this.PART_DeleteButton = this.GetTemplateChild(nameof(PART_DeleteButton)) as Button;
 
             if (this.PART_LabelBorder != null)
@@ -153,6 +160,7 @@ namespace AJut.UX.Controls
             this.ApplyLabelTemplate();
             this.ApplySubtitle();
             this.ApplyDeleteButton();
+            this.ApplyListElementHeader();
             this.ApplyToolTips();
 
             if (m_flatTreeItem != null)
@@ -250,10 +258,14 @@ namespace AJut.UX.Controls
             //     the enclosing PropertyGrid.
             // Without deferral, DataContextChanged fires before template application on
             // newly created rows, making PART_EditorContent null at call time.
-            var capturedTarget = m_editTarget;
+            // Guard with a revision token rather than capturing m_editTarget: capturing the
+            // target would let this queued callback hold the target (and through it the source
+            // object) alive until the dispatcher pumps. Harmless in a live app, but it makes a
+            // disposed grid's source look pinned to a leak probe that GCs before the queue drains.
+            int revision = ++m_dataContextRevision;
             this.DispatcherQueue.TryEnqueue(() =>
             {
-                if (m_editTarget == capturedTarget)
+                if (m_dataContextRevision == revision)
                 {
                     this.ApplyEditorContent();
                 }
@@ -262,6 +274,7 @@ namespace AJut.UX.Controls
             this.ApplyLabelTemplate();
             this.ApplySubtitle();
             this.ApplyDeleteButton();
+            this.ApplyListElementHeader();
             this.ApplyToolTips();
         }
 
@@ -288,6 +301,11 @@ namespace AJut.UX.Controls
                 || e.PropertyName == nameof(PropertyEditTarget.DisplayName))
             {
                 this.ApplyToolTips();
+            }
+            else if (e.PropertyName == nameof(PropertyEditTarget.IsListElementHeaderVisible)
+                || e.PropertyName == nameof(PropertyEditTarget.ListElementHeaderText))
+            {
+                this.ApplyListElementHeader();
             }
         }
 
@@ -379,6 +397,18 @@ namespace AJut.UX.Controls
             this.PART_DeleteButton.Visibility = (m_editTarget?.CanRemoveFromList == true)
                 ? Visibility.Visible
                 : Visibility.Collapsed;
+        }
+
+        private void ApplyListElementHeader ()
+        {
+            if (this.PART_ListElementHeader == null)
+            {
+                return;
+            }
+
+            bool visible = m_editTarget?.IsListElementHeaderVisible == true;
+            this.PART_ListElementHeader.Text = visible ? (m_editTarget.ListElementHeaderText ?? string.Empty) : string.Empty;
+            this.PART_ListElementHeader.Visibility = visible ? Visibility.Visible : Visibility.Collapsed;
         }
 
 

--- a/libs/AJut.UX.WinUI3/Controls/PropertyGridItemRow.xaml
+++ b/libs/AJut.UX.WinUI3/Controls/PropertyGridItemRow.xaml
@@ -103,6 +103,18 @@
                                             Visibility="{Binding Source.HasInlineEditor, Converter={StaticResource PGItemRow_BoolToVis}}"
                                             ContentTemplateSelector="{TemplateBinding EditorTemplateSelector}"/>
 
+                            <!-- PART_ListElementHeader: for an expandable list element row (no inline editor),
+                                 fills the value column with the [PGList] ElementDisplayMemberName value.
+                                 Text and Visibility are applied in code. Shares column 1 with PART_EditorContent
+                                 but never shows at the same time (IsListElementHeaderVisible requires no inline editor). -->
+                            <TextBlock x:Name="PART_ListElementHeader"
+                                       Grid.Column="1"
+                                       VerticalAlignment="Center"
+                                       Margin="5,0,0,0"
+                                       Opacity="0.85"
+                                       TextTrimming="CharacterEllipsis"
+                                       Visibility="Collapsed"/>
+
                             <!-- Delete button for list elements. Visibility and Command managed in code.
                                  Only shown when the target is a list element with CanRemove. -->
                             <Button x:Name="PART_DeleteButton"

--- a/libs/AJut.UX.WinUI3/Controls/ToggleStrip.cs
+++ b/libs/AJut.UX.WinUI3/Controls/ToggleStrip.cs
@@ -369,12 +369,20 @@ namespace AJut.UX.Controls
                 }
             });
 
-            this.SelectionChanged?.Invoke(
-                this,
-                new ToggleStripSelectionChangedEventArgs(previousSelectedItems, newlySelectedItems)
-            );
+            this.RaiseSelectionChanged(previousSelectedItems, newlySelectedItems);
 
             this.RefreshForSelection();
+        }
+
+        // Owner-side raiser for the public SelectionChanged event. Both the select path
+        // (HandleSelectionChanged) and the multi-select deselect path (ToggleItemsCollection.
+        // HandleWasDeselected) funnel through here so the event is raised consistently.
+        internal void RaiseSelectionChanged (IList previousSelection, IList currentSelection)
+        {
+            this.SelectionChanged?.Invoke(
+                this,
+                new ToggleStripSelectionChangedEventArgs(previousSelection, currentSelection)
+            );
         }
 
         // ===========[ Item building ]============================================
@@ -817,7 +825,9 @@ namespace AJut.UX.Controls
                 this.RaisePropertyChanged(nameof(IsSelected));
                 if (!isSelected)
                 {
-                    this.Owner.Items.HandleWasDeselected(this);
+                    // This runs only as the deselect half of a single-select swap (the follow-on select
+                    // raises SelectionChanged for the whole change), so flag it to suppress a duplicate raise.
+                    this.Owner.Items.HandleWasDeselected(this, isPartOfSelectionSwap: true);
                 }
             }
 
@@ -881,8 +891,12 @@ namespace AJut.UX.Controls
                 m_owner.HandleSelectionChanged(newlySelected);
             }
 
-            internal void HandleWasDeselected (ToggleItem toggleItem)
+            internal void HandleWasDeselected (ToggleItem toggleItem, bool isPartOfSelectionSwap = false)
             {
+                // Snapshot the selection as it stood before this deselect so a raised SelectionChanged
+                // reports an accurate previous set (the bookkeeping below mutates SelectedItems in place).
+                IList previousSelection = m_owner.SelectedItems?.OfType<object>().ToList() ?? new List<object>();
+
                 if (m_owner.SelectedItems is INotifyCollectionChanged)
                 {
                     m_owner.SelectedItems.Remove(toggleItem.Data);
@@ -896,6 +910,17 @@ namespace AJut.UX.Controls
                     m_owner.SelectedItems = m_owner.SelectedItems.OfType<object>()
                         .Where(i => !Equals(i, toggleItem.Data))
                         .ToList<object>();
+                }
+
+                // A standalone deselect changes the selection in its own right, so raise it here. The one
+                // deselect that must NOT raise is the internal first-half of a single-select swap (via
+                // SetSelectionWithoutChecking): that swap's follow-on select already raises once for the
+                // whole change, so raising here too would double-fire. This is the only suppression case -
+                // multi-select deselects and single-select deselect-to-empty (AllowNoSelection) both raise.
+                if (!isPartOfSelectionSwap)
+                {
+                    IList currentSelection = this.Where(ti => ti.IsSelected).Select(ti => ti.Data).ToList();
+                    m_owner.RaiseSelectionChanged(previousSelection, currentSelection);
                 }
             }
 

--- a/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
+++ b/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
@@ -15,7 +15,7 @@
     <PackageTags>c#;dotnet;wpf;theming;controls;converters;app;utilities</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.5.6.126</Version>
+    <Version>1.5.7.127</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="8.0.8" />

--- a/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
+++ b/libs/AJut.UX.Wpf/Controls/FlatTreeListControl.cs
@@ -442,6 +442,81 @@ namespace AJut.UX.Controls
             this.PART_ListBoxDisplay?.Focus();
         }
 
+        /// <summary>
+        /// Selects the row wrapping the given source node, expanding any collapsed ancestors first so the
+        /// row joins the visible list, and optionally scrolling it into view. Returns false when no row
+        /// matches the source or the control isn't ready to take a selection yet.
+        /// </summary>
+        public bool TrySelectItemForSource (IObservableTreeNode source, bool scrollIntoView = true)
+        {
+            if (this.PART_ListBoxDisplay == null || source == null)
+            {
+                return false;
+            }
+
+            // Walk AllChildren (visible + collapsed) rather than StorageItemForNode's TreeTraversal so the
+            // search reaches rows parked inside collapsed parents - which is exactly what we then expand to.
+            FlatTreeItem item = _FindItemForSource(this.Items?.RootNode, source);
+            if (item == null)
+            {
+                return false;
+            }
+
+            // Expand collapsed ancestors top-down so the target row moves out of its parents'
+            // hidden-children lists and into the visible list before we select / scroll to it.
+            var ancestry = new List<FlatTreeItem>();
+            for (FlatTreeItem ancestor = item.Parent; ancestor != null; ancestor = ancestor.Parent)
+            {
+                ancestry.Add(ancestor);
+            }
+
+            for (int i = ancestry.Count - 1; i >= 0; --i)
+            {
+                if (ancestry[i].IsExpandable && !ancestry[i].IsExpanded)
+                {
+                    ancestry[i].IsExpanded = true;
+                }
+            }
+
+            this.SelectedItem = source;
+
+            if (scrollIntoView)
+            {
+                // Rows revealed by the expansion above aren't laid out yet; defer the scroll to the
+                // dispatcher (background priority) so the ListBox has realized them before we scroll.
+                void ScrollToItem () => this.PART_ListBoxDisplay?.ScrollIntoView(item);
+                this.Dispatcher.BeginInvoke((Action)ScrollToItem, System.Windows.Threading.DispatcherPriority.Background);
+            }
+
+            return true;
+        }
+
+        // Recurse via AllChildren (visible + collapsed) so the search reaches rows parked inside collapsed
+        // parents - which is exactly what programmatic selection must expand to.
+        private static FlatTreeItem _FindItemForSource (FlatTreeItem node, IObservableTreeNode source)
+        {
+            if (node == null)
+            {
+                return null;
+            }
+
+            if (node.Source == source)
+            {
+                return node;
+            }
+
+            foreach (FlatTreeItem child in node.AllChildren)
+            {
+                FlatTreeItem found = _FindItemForSource(child, source);
+                if (found != null)
+                {
+                    return found;
+                }
+            }
+
+            return null;
+        }
+
         protected override void OnKeyUp (KeyEventArgs e)
         {
             if (e.Key == Key.Left)

--- a/libs/AJut.UX.Wpf/Controls/PropertyGrid.cs
+++ b/libs/AJut.UX.Wpf/Controls/PropertyGrid.cs
@@ -48,6 +48,15 @@ namespace AJut.UX.Controls
 
         public void Dispose ()
         {
+            if (this.PART_TreeList != null)
+            {
+                this.PART_TreeList.DragDropReorderRequested -= this.OnDragDropReorderRequested;
+            }
+
+            // Drop the per-target subscriptions and each target's elevated INPC hooks while the
+            // tree is still walkable. m_manager.Dispose() only clears collections; without this a
+            // long-lived source object keeps the disposed grid (and its target tree) alive.
+            this._TeardownTargetSubscriptions();
             m_manager.Dispose();
             this.ItemsSource = null;
             this.SingleItemSource = null;
@@ -237,6 +246,7 @@ namespace AJut.UX.Controls
             }
             else
             {
+                this._TeardownTargetSubscriptions();
                 m_manager.Dispose();
                 this.PropertyTreeItems = null;
             }
@@ -272,6 +282,7 @@ namespace AJut.UX.Controls
             }
             else
             {
+                this._TeardownTargetSubscriptions();
                 m_manager.Dispose();
                 this.PropertyTreeItems = null;
             }
@@ -315,20 +326,7 @@ namespace AJut.UX.Controls
         private void RebuildEditTargets ()
         {
             // Unsubscribe from old tree (and hidden conditional targets) before rebuild.
-            if (m_manager.RootNode != null)
-            {
-                foreach (var target in _WalkAllTargets(m_manager.RootNode))
-                {
-                    target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
-                    target.Teardown();
-                }
-
-                foreach (var target in m_manager.HiddenConditionalTargets)
-                {
-                    target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
-                    target.Teardown();
-                }
-            }
+            this._TeardownTargetSubscriptions();
 
             m_manager.RebuildEditTargets();
             this.PropertyTreeItems = m_manager.RootNode != null
@@ -384,6 +382,30 @@ namespace AJut.UX.Controls
                 // A property edit may change a ShowIf/HideIf condition - toggle
                 // affected targets in/out without a full rebuild.
                 m_manager.UpdateConditionalVisibility();
+            }
+        }
+
+        // Drops every per-target PropertyChanged subscription and tears down each target's elevated
+        // sub-object INPC hooks. Walks the live tree plus the hidden-conditional targets (which are
+        // subscribed even while out of the tree). Called before every rebuild and on dispose / source
+        // clear so a torn-down grid does not leave subscriptions pinning the target/source graph.
+        private void _TeardownTargetSubscriptions ()
+        {
+            if (m_manager.RootNode == null)
+            {
+                return;
+            }
+
+            foreach (var target in _WalkAllTargets(m_manager.RootNode))
+            {
+                target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
+                target.Teardown();
+            }
+
+            foreach (var target in m_manager.HiddenConditionalTargets)
+            {
+                target.PropertyChanged -= this.OnAnyTargetPropertyChanged;
+                target.Teardown();
             }
         }
 

--- a/libs/AJut.UX.Wpf/Controls/PropertyGrid.cs
+++ b/libs/AJut.UX.Wpf/Controls/PropertyGrid.cs
@@ -20,6 +20,11 @@ namespace AJut.UX.Controls
         private readonly PropertyGridManager m_manager;
         private FlatTreeListControl PART_TreeList;
 
+        // Last source object reported through SelectedSourceObjectChanged. Held so we only raise that
+        // event when the resolved element actually changes - not when selection moves between two rows
+        // inside the same element's subtree.
+        private object m_lastSelectedSourceObject;
+
         // ===========[ Commands ]=================================================
         /// <summary>
         /// Resets the target PropertyEditTarget (passed as CommandParameter) to its default value.
@@ -50,6 +55,7 @@ namespace AJut.UX.Controls
         {
             if (this.PART_TreeList != null)
             {
+                this.PART_TreeList.SelectionChanged -= this.OnTreeListSelectionChanged;
                 this.PART_TreeList.DragDropReorderRequested -= this.OnDragDropReorderRequested;
             }
 
@@ -68,6 +74,7 @@ namespace AJut.UX.Controls
 
             if (this.PART_TreeList != null)
             {
+                this.PART_TreeList.SelectionChanged -= this.OnTreeListSelectionChanged;
                 this.PART_TreeList.DragDropReorderRequested -= this.OnDragDropReorderRequested;
             }
 
@@ -78,6 +85,8 @@ namespace AJut.UX.Controls
                 this.PART_TreeList.CanDragItem = _CanDragPropertyItem;
                 this.PART_TreeList.CanDropItem = _CanDropPropertyItem;
                 this.PART_TreeList.DragDropReorderRequested += this.OnDragDropReorderRequested;
+
+                this.PART_TreeList.SelectionChanged += this.OnTreeListSelectionChanged;
 
                 this.PART_TreeList.DragGhostTemplate = this.DragGhostTemplate;
             }
@@ -323,6 +332,74 @@ namespace AJut.UX.Controls
         /// </summary>
         public event EventHandler PropertyTreeChanged;
 
+        /// <summary>
+        /// Fires whenever the selected row changes - by user click or programmatic selection. Read
+        /// <see cref="SelectedTarget"/> / <see cref="SelectedSourceObject"/> in the handler.
+        /// </summary>
+        public event EventHandler SelectedTargetChanged;
+
+        /// <summary>
+        /// Fires when the source object behind the selected row changes. Moving the selection between two
+        /// rows inside the same list element's subtree resolves to the same element, so this does NOT fire
+        /// in that case - only when the resolved <see cref="SelectedSourceObject"/> actually changes.
+        /// </summary>
+        public event EventHandler SelectedSourceObjectChanged;
+
+        // ===========[ Selection ]================================================
+        /// <summary>
+        /// The PropertyEditTarget behind the currently selected row, or null when nothing is selected.
+        /// Setting it selects that row (expanding any collapsed ancestors) and scrolls it into view; set
+        /// to null to clear the selection. Returns null until the template has been applied.
+        /// </summary>
+        public PropertyEditTarget SelectedTarget
+        {
+            get => this.PART_TreeList?.SelectedItem as PropertyEditTarget;
+            set
+            {
+                if (this.PART_TreeList == null)
+                {
+                    return;
+                }
+
+                if (value == null)
+                {
+                    this.PART_TreeList.SelectedItems.Clear();
+                    return;
+                }
+
+                this.PART_TreeList.TrySelectItemForSource(value, scrollIntoView: true);
+            }
+        }
+
+        /// <summary>
+        /// The source object behind the selected row, resolved by walking up from the selected row to the
+        /// nearest list-element row and returning its element instance. Null when nothing is selected or
+        /// the selection sits outside any list element. Selecting any row inside an element's subtree
+        /// (the element row itself or any of its sub-property rows) resolves to that same element.
+        /// </summary>
+        public object SelectedSourceObject => _ResolveSourceObject(this.SelectedTarget);
+
+        /// <summary>
+        /// Selects the row representing <paramref name="sourceObject"/> (matched by reference), expanding
+        /// any collapsed ancestors and scrolling it into view. Returns false when no row represents the
+        /// instance. Only list-element rows carry a source object, so this targets list elements.
+        /// </summary>
+        public bool TrySelectSourceObject (object sourceObject)
+        {
+            if (sourceObject == null || this.PART_TreeList == null)
+            {
+                return false;
+            }
+
+            PropertyEditTarget match = this.FindTargetForSourceObject(sourceObject);
+            if (match == null)
+            {
+                return false;
+            }
+
+            return this.PART_TreeList.TrySelectItemForSource(match, scrollIntoView: true);
+        }
+
         private void RebuildEditTargets ()
         {
             // Unsubscribe from old tree (and hidden conditional targets) before rebuild.
@@ -427,6 +504,53 @@ namespace AJut.UX.Controls
                     }
                 }
             }
+        }
+
+        // ===========[ Selection handling ]=======================================
+        private void OnTreeListSelectionChanged (object sender, EventArgs<SelectionChange<IObservableTreeNode>> e)
+        {
+            this.SelectedTargetChanged?.Invoke(this, EventArgs.Empty);
+
+            object newSource = this.SelectedSourceObject;
+            if (!ReferenceEquals(newSource, m_lastSelectedSourceObject))
+            {
+                m_lastSelectedSourceObject = newSource;
+                this.SelectedSourceObjectChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private PropertyEditTarget FindTargetForSourceObject (object sourceObject)
+        {
+            if (m_manager.RootNode == null)
+            {
+                return null;
+            }
+
+            foreach (PropertyEditTarget target in _WalkAllTargets(m_manager.RootNode))
+            {
+                if (ReferenceEquals(target.SourceObject, sourceObject))
+                {
+                    return target;
+                }
+            }
+
+            return null;
+        }
+
+        // Walk up (including the row itself) to the nearest row that stands in for a source object - i.e.
+        // the nearest list-element ancestor - and return its element instance.
+        private static object _ResolveSourceObject (PropertyEditTarget target)
+        {
+            for (PropertyEditTarget cursor = target; cursor != null; cursor = cursor.Parent as PropertyEditTarget)
+            {
+                object source = cursor.SourceObject;
+                if (source != null)
+                {
+                    return source;
+                }
+            }
+
+            return null;
         }
 
         private void OnSetPropertyToDefaultExecuted (object sender, ExecutedRoutedEventArgs e)

--- a/libs/AJut.UX.Wpf/Controls/PropertyGrid.xaml
+++ b/libs/AJut.UX.Wpf/Controls/PropertyGrid.xaml
@@ -209,6 +209,18 @@
                                         </ContentPresenter.Style>
                                     </ContentPresenter>
 
+                                    <!-- List element header: fills the value column for an expandable element row
+                                         (which has no inline editor) with the [PGList] ElementDisplayMemberName value.
+                                         IsListElementHeaderVisible already gates on there being no inline editor, so
+                                         this never collides with the editor above. -->
+                                    <TextBlock Grid.Column="1"
+                                               Text="{Binding ListElementHeaderText}"
+                                               VerticalAlignment="Center"
+                                               Margin="5,0,0,0"
+                                               Opacity="0.85"
+                                               TextTrimming="CharacterEllipsis"
+                                               Visibility="{Binding IsListElementHeaderVisible, Converter={conv:BooleanToVisibilityConverter TrueValue=Visible, FalseValue=Collapsed}}"/>
+
                                     <!-- Delete button for list elements. Only visible when CanRemoveFromList. -->
                                     <Button Grid.Column="2"
                                             VerticalAlignment="Center"

--- a/libs/AJut.UX.Wpf/Controls/ToggleStrip.cs
+++ b/libs/AJut.UX.Wpf/Controls/ToggleStrip.cs
@@ -538,7 +538,7 @@
                 }
             );
 
-            this.SelectionChanged?.Invoke(this, new ToggleStripSelectionChangedEventArgs(previousSelectedItems, newlySelectedItems));
+            this.RaiseSelectionChanged(previousSelectedItems, newlySelectedItems);
 
             // Selection changing can pull a selected item back into view (it is kept visible where
             // possible), so re-run the overflow partition.
@@ -558,6 +558,14 @@
                     );
                 }
             }
+        }
+
+        // Owner-side raiser for the public SelectionChanged event. Both the select path
+        // (HandleSelectionChanged) and the multi-select deselect path (ToggleItemsCollection.
+        // HandleWasDeselected) funnel through here so the event is raised consistently.
+        internal void RaiseSelectionChanged (IList previousSelection, IList currentSelection)
+        {
+            this.SelectionChanged?.Invoke(this, new ToggleStripSelectionChangedEventArgs(previousSelection, currentSelection));
         }
 
         // ================== [ Utility Classes ]================================
@@ -676,7 +684,10 @@
             {
                 m_isSelected = isSelected;
                 this.RaisePropertyChanged(nameof(IsSelected));
-                this.Owner.Items.HandleWasDeselected(this);
+
+                // This runs only as the deselect half of a single-select swap (the follow-on select
+                // raises SelectionChanged for the whole change), so flag it to suppress a duplicate raise.
+                this.Owner.Items.HandleWasDeselected(this, isPartOfSelectionSwap: true);
             }
 
             private void ResetNameWithDefault ()
@@ -717,8 +728,12 @@
                 m_owner.HandleSelectionChanged(newlySelected);
             }
 
-            internal void HandleWasDeselected (ToggleItem toggleItem)
+            internal void HandleWasDeselected (ToggleItem toggleItem, bool isPartOfSelectionSwap = false)
             {
+                // Snapshot the selection as it stood before this deselect so a raised SelectionChanged
+                // reports an accurate previous set (the bookkeeping below mutates SelectedItems in place).
+                IList previousSelection = m_owner.SelectedItems?.OfType<object>().ToList() ?? new List<object>();
+
                 if (m_owner.SelectedItems is INotifyCollectionChanged)
                 {
                     m_owner.SelectedItems.Remove(toggleItem.Data);
@@ -730,6 +745,17 @@
                 else
                 {
                     m_owner.SelectedItems = m_owner.SelectedItems.OfType<object>().Where(i => i != toggleItem.Data).ToList();
+                }
+
+                // A standalone deselect changes the selection in its own right, so raise it here. The one
+                // deselect that must NOT raise is the internal first-half of a single-select swap (via
+                // SetSelectionWithoutChecking): that swap's follow-on select already raises once for the
+                // whole change, so raising here too would double-fire. This is the only suppression case -
+                // multi-select deselects and single-select deselect-to-empty (AllowNoSelection) both raise.
+                if (!isPartOfSelectionSwap)
+                {
+                    IList currentSelection = this.Where(_ => _.IsSelected).Select(_ => _.Data).ToList();
+                    m_owner.RaiseSelectionChanged(previousSelection, currentSelection);
                 }
             }
 

--- a/libs/AJut.UX/AJut.UX.csproj
+++ b/libs/AJut.UX/AJut.UX.csproj
@@ -14,7 +14,7 @@
     <PackageTags>c#;dotnet;theming;controls;converters;app;utilities</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <Version>1.1.6.126</Version>
+    <Version>1.1.7.127</Version>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\ajut-logo-128.png">

--- a/libs/AJut.UX/PropertyInteraction/Attributes/PGListAttribute.cs
+++ b/libs/AJut.UX/PropertyInteraction/Attributes/PGListAttribute.cs
@@ -49,5 +49,20 @@ namespace AJut.UX.PropertyInteraction
         /// Whether new elements can be added. Defaults to true.
         /// </summary>
         public bool CanAdd { get; set; } = true;
+
+        /// <summary>
+        /// Optional name of a member on the element type whose value fills the element row's value
+        /// column (the otherwise-blank space beside the "[index]" label). May name a method (zero
+        /// parameters), property, or field, instance or static. The resolved value is shown via
+        /// ToString. When null no element header is shown.
+        /// </summary>
+        public string ElementDisplayMemberName { get; set; }
+
+        /// <summary>
+        /// When <see cref="ElementDisplayMemberName"/> is set, controls whether the header shows in
+        /// every state or only while the element row is collapsed. Defaults to
+        /// <see cref="eElementHeaderDisplay.Always"/>.
+        /// </summary>
+        public eElementHeaderDisplay ElementDisplayMemberVisibility { get; set; } = eElementHeaderDisplay.Always;
     }
 }

--- a/libs/AJut.UX/PropertyInteraction/PropertyEditTarget.cs
+++ b/libs/AJut.UX/PropertyInteraction/PropertyEditTarget.cs
@@ -75,6 +75,15 @@ namespace AJut.UX.PropertyInteraction
         /// <summary>The remove command for list elements (null when not a removable list element).</summary>
         public System.Windows.Input.ICommand ListElementRemoveCommand => (this.EditContext as PropertyGridListElementContext)?.RemoveCommand;
 
+        /// <summary>
+        /// The discrete source object this row stands in for. For a list element row this is the element
+        /// instance currently at the row's index - read live, so it tracks reorders and replacements. For
+        /// every other row it is null, since those rows edit a property value rather than representing an
+        /// object. The PropertyGrid walks up from the selected row to the nearest row with a non-null
+        /// SourceObject to answer "which element owns this row".
+        /// </summary>
+        public object? SourceObject => this.IsListElement ? m_getValue?.Invoke() : null;
+
         /// <summary>True when this row should show an inline editor.</summary>
         public bool HasInlineEditor => !this.IsExpandable || this.ElevatedChildTarget != null || this.IsListEditor;
 

--- a/libs/AJut.UX/PropertyInteraction/PropertyEditTarget.cs
+++ b/libs/AJut.UX/PropertyInteraction/PropertyEditTarget.cs
@@ -26,6 +26,10 @@ namespace AJut.UX.PropertyInteraction
         private PropertyEditTarget m_elevatedChildTarget;
         private INotifyPropertyChanged m_elevatedSubObject;
         private INotifyPropertyChanged m_editValueINPC;
+        private string m_listElementHeaderText;
+        private Func<string> m_listElementHeaderResolver;
+        private bool m_listElementHeaderShownWhenExpanded = true;
+        private INotifyPropertyChanged m_listElementHeaderSource;
 
         public PropertyEditTarget(string propertyPathTarget, GetValue getValue, SetValue? setValue = null)
         {
@@ -115,7 +119,17 @@ namespace AJut.UX.PropertyInteraction
         public bool IsExpanded
         {
             get => m_isExpanded;
-            set => this.SetAndRaiseIfChanged(ref m_isExpanded, value);
+            set
+            {
+                if (this.SetAndRaiseIfChanged(ref m_isExpanded, value))
+                {
+                    // A collapse can follow an edit made while the row was expanded, so re-resolve the
+                    // element header to pick up the latest value, then refresh its visibility either way
+                    // (a "when collapsed" header toggles in/out as the row expands and collapses).
+                    this.RefreshListElementHeader();
+                    this.RaisePropertyChanged(nameof(IsListElementHeaderVisible));
+                }
+            }
         }
 
         private string m_editor;
@@ -138,6 +152,32 @@ namespace AJut.UX.PropertyInteraction
             get => m_subtitle;
             set => this.SetAndRaiseIfChanged(ref m_subtitle, value);
         }
+
+        /// <summary>
+        /// For a list element row, the text shown in the value column beside the "[index]" label,
+        /// resolved from [PGList]'s ElementDisplayMemberName. Null/empty when no header is configured.
+        /// </summary>
+        public string ListElementHeaderText
+        {
+            get => m_listElementHeaderText;
+            set
+            {
+                if (this.SetAndRaiseIfChanged(ref m_listElementHeaderText, value))
+                {
+                    this.RaisePropertyChanged(nameof(IsListElementHeaderVisible));
+                }
+            }
+        }
+
+        /// <summary>
+        /// True when the element header should currently render: it has text, this row has no inline
+        /// editor occupying the value column, and the configured display mode allows it in the row's
+        /// current expand state. Recomputed live; change is raised from the text and IsExpanded setters.
+        /// </summary>
+        public bool IsListElementHeaderVisible
+            => !string.IsNullOrEmpty(this.ListElementHeaderText)
+                && !this.HasInlineEditor
+                && (m_listElementHeaderShownWhenExpanded || !this.IsExpanded);
 
         private string m_toolTip;
 
@@ -297,6 +337,49 @@ namespace AJut.UX.PropertyInteraction
             }
 
             m_elevatedChildTarget?.RecacheEditValue();
+        }
+
+        /// <summary>
+        /// Wires up the element header for a list element row: stores the resolver and display mode, then
+        /// resolves the initial value. When <paramref name="headerSource"/> implements INotifyPropertyChanged
+        /// (the typical case - the element itself), subscribes so any property change on the element refreshes
+        /// the header live. The subscription is dropped in <see cref="Teardown"/>, which the PropertyGrid
+        /// runs for every target on rebuild and dispose. Non-INPC elements still refresh on rebuild and on
+        /// expand/collapse (see <see cref="IsExpanded"/>).
+        /// </summary>
+        internal void ConfigureListElementHeader (object headerSource, Func<string> resolver, eElementHeaderDisplay visibility)
+        {
+            m_listElementHeaderResolver = resolver;
+            m_listElementHeaderShownWhenExpanded = visibility == eElementHeaderDisplay.Always;
+
+            if (m_listElementHeaderSource != null)
+            {
+                m_listElementHeaderSource.PropertyChanged -= this.OnListElementHeaderSourceChanged;
+            }
+
+            m_listElementHeaderSource = headerSource as INotifyPropertyChanged;
+            if (m_listElementHeaderSource != null)
+            {
+                m_listElementHeaderSource.PropertyChanged += this.OnListElementHeaderSourceChanged;
+            }
+
+            this.RefreshListElementHeader();
+        }
+
+        /// <summary>Re-runs the element header resolver (if one was configured) and updates the text.</summary>
+        public void RefreshListElementHeader ()
+        {
+            if (m_listElementHeaderResolver != null)
+            {
+                this.ListElementHeaderText = m_listElementHeaderResolver();
+            }
+        }
+
+        // Any change on the element refreshes the header - property-name agnostic so it also covers
+        // method- and field-derived headers (e.g. a header built from two of the element's properties).
+        private void OnListElementHeaderSourceChanged (object sender, PropertyChangedEventArgs e)
+        {
+            this.RefreshListElementHeader();
         }
 
         /// <summary>
@@ -683,6 +766,62 @@ namespace AJut.UX.PropertyInteraction
                         || TypeMetadataExtensionRegistrar.HasAttribute<PGShowReadonlyAttribute>(_prop);
                 }
             }
+        }
+
+        /// <summary>
+        /// Resolves a display string from a named member on a list element. The member may be a
+        /// property, a field, or a zero-parameter method - instance or static. Returns the value's
+        /// ToString, or null when the member is missing, the value is null, or an instance member was
+        /// asked for with no element to read from.
+        /// </summary>
+        internal static string ResolveDisplayMember (Type elementType, object element, string memberName)
+        {
+            if (elementType == null || string.IsNullOrEmpty(memberName))
+            {
+                return null;
+            }
+
+            const BindingFlags kFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static;
+
+            // 1. Property
+            PropertyInfo prop = elementType.GetProperty(memberName, kFlags);
+            if (prop != null)
+            {
+                bool isStatic = prop.GetGetMethod(true)?.IsStatic == true;
+                if (!isStatic && element == null)
+                {
+                    return null;
+                }
+
+                return prop.GetValue(isStatic ? null : element)?.ToString();
+            }
+
+            // 2. Field
+            FieldInfo field = elementType.GetField(memberName, kFlags);
+            if (field != null)
+            {
+                if (!field.IsStatic && element == null)
+                {
+                    return null;
+                }
+
+                return field.GetValue(field.IsStatic ? null : element)?.ToString();
+            }
+
+            // 3. Zero-parameter method
+            MethodInfo method = elementType.GetMethod(memberName, kFlags, null, Type.EmptyTypes, null);
+            if (method != null)
+            {
+                if (!method.IsStatic && element == null)
+                {
+                    return null;
+                }
+
+                return method.Invoke(method.IsStatic ? null : element, null)?.ToString();
+            }
+
+            Logger.LogError($"PGList: ElementDisplayMemberName member '{memberName}' not found on '{elementType.Name}'");
+            return null;
         }
 
         /// <summary>
@@ -1166,6 +1305,19 @@ namespace AJut.UX.PropertyInteraction
                     }
                 }
 
+                // ------ Element header: fill the otherwise-blank value column with a member-resolved label ------
+                if (!string.IsNullOrEmpty(listAttr.ElementDisplayMemberName) && element != null)
+                {
+                    object capturedElement = element;
+                    Type capturedHeaderType = elementType;
+                    string capturedMember = listAttr.ElementDisplayMemberName;
+                    childTarget.ConfigureListElementHeader(
+                        capturedElement,
+                        () => ResolveDisplayMember(capturedHeaderType, capturedElement, capturedMember),
+                        listAttr.ElementDisplayMemberVisibility
+                    );
+                }
+
                 childTarget.Setup();
                 listParent.InsertChild(listParent.Children.Count, childTarget);
                 ++index;
@@ -1421,6 +1573,12 @@ namespace AJut.UX.PropertyInteraction
             {
                 m_editValueINPC.PropertyChanged -= this.OnEditValueSubPropertyChanged;
                 m_editValueINPC = null;
+            }
+
+            if (m_listElementHeaderSource != null)
+            {
+                m_listElementHeaderSource.PropertyChanged -= this.OnListElementHeaderSourceChanged;
+                m_listElementHeaderSource = null;
             }
         }
 

--- a/libs/AJut.UX/PropertyInteraction/PropertyGridManager.cs
+++ b/libs/AJut.UX/PropertyInteraction/PropertyGridManager.cs
@@ -80,6 +80,14 @@ namespace AJut.UX.PropertyInteraction
             this.SnapshotExpandedStates();
             this.Items.Clear();
             this.RootNode = null;
+
+            // These hold PropertyEditTargets (which reach back to the source object). RebuildEditTargets
+            // clears them on every rebuild; Dispose must too, or a disposed grid keeps the source graph
+            // pinned through them. m_expandedStates is intentionally preserved (snapshot for restore).
+            m_visibilityConditions.Clear();
+            m_naturalChildOrder.Clear();
+            m_groupHeaders.Clear();
+            m_hasConditionalVisibility = false;
         }
 
         public void RebuildEditTargets ()

--- a/libs/AJut.UX/PropertyInteraction/eElementHeaderDisplay.cs
+++ b/libs/AJut.UX/PropertyInteraction/eElementHeaderDisplay.cs
@@ -1,0 +1,15 @@
+namespace AJut.UX.PropertyInteraction
+{
+    /// <summary>
+    /// Controls when a list element row in the <see cref="PropertyGrid"/> shows its
+    /// element header (the value resolved from <see cref="Attributes.PGListAttribute.ElementDisplayMemberName"/>).
+    /// </summary>
+    public enum eElementHeaderDisplay
+    {
+        /// <summary>Show the header whether the element row is expanded or collapsed.</summary>
+        Always,
+
+        /// <summary>Show the header only while the element row is collapsed.</summary>
+        WhenCollapsed,
+    }
+}

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -788,7 +788,16 @@
                                                Text="(diagnostics will appear here after clicking a Mode button)"/>
                                 </StackPanel>
 
-                                <TextBlock Grid.Row="2" Grid.Column="0" Text="PropertyGrid - switch sources above to test live refresh" FontStyle="Italic" Margin="0,0,0,8"/>
+                                <!-- Selection-surface tester: exercises TrySelectSourceObject / SelectedSourceObject(Changed).
+                                     Complex A/B have ListWithElevation (complex elements with identity) to target. -->
+                                <StackPanel Grid.Row="2" Grid.Column="0" Orientation="Horizontal" Spacing="6" Margin="0,0,0,8">
+                                    <TextBlock Text="PropertyGrid - switch sources above to test live refresh" FontStyle="Italic" VerticalAlignment="Center"/>
+                                    <Button Content="Select random element" Click="PGSelect_OnRandomElementClicked"
+                                            ToolTipService.ToolTip="Complex A/B: TrySelectSourceObject on a random ListWithElevation element - exercises programmatic select + scroll, verifies no Single-mode COMException, and the collapsed-target expand path"/>
+                                    <Button Content="Clear selection" Click="PGSelect_OnClearClicked"/>
+                                    <TextBlock Text="SelectedSourceObject:" VerticalAlignment="Center"/>
+                                    <TextBlock x:Name="PGSelectionReadout" Text="(none)" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                </StackPanel>
                                 <TextBlock Grid.Row="2" Grid.Column="2" Text="Live source object (JSON)" FontStyle="Italic" Margin="0,0,0,8"/>
 
                                 <!-- SingleItemSource set in code-behind so we can swap it via the buttons above -->

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -885,22 +885,40 @@
                                                Text="Each probe builds a fresh instance against this window, disposes it, drops the strong ref, then forces GC and checks that the WeakReference is dead. PASS means the instance got collected. FAIL means something is still pinning it (likely an event subscription that didn't get unhooked in Dispose)."/>
 
                                     <StackPanel Spacing="6">
-                                        <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <Button Content="Probe DockingManager" Click="LeakProbe_OnDockingManagerClicked" MinWidth="220"/>
-                                            <TextBlock x:Name="LeakProbe_DockingManagerStatus" VerticalAlignment="Center" FontFamily="Consolas" Opacity="0.85"
-                                                       Text="(not run yet)"/>
-                                        </StackPanel>
-                                        <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <Button Content="Probe WindowManager" Click="LeakProbe_OnWindowManagerClicked" MinWidth="220"/>
-                                            <TextBlock x:Name="LeakProbe_WindowManagerStatus" VerticalAlignment="Center" FontFamily="Consolas" Opacity="0.85"
-                                                       Text="(not run yet)"/>
-                                        </StackPanel>
-                                        <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <Button Content="Probe x5 (open/close cycles)" Click="LeakProbe_OnCycleClicked" MinWidth="220"/>
-                                            <TextBlock x:Name="LeakProbe_CycleStatus" VerticalAlignment="Center" FontFamily="Consolas" Opacity="0.85"
-                                                       Text="(not run yet)"/>
-                                        </StackPanel>
+                                        <Button Content="Probe DockingManager" Click="LeakProbe_OnDockingManagerClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                        <Button Content="Probe WindowManager" Click="LeakProbe_OnWindowManagerClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                        <Button Content="Probe x5 (open/close cycles)" Click="LeakProbe_OnCycleClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                        <Button Content="Dock leak - child window" Click="LeakProbe_OnChildWindowDockingClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                        <Button Content="Dock leak - main window (control)" Click="LeakProbe_OnMainWindowDockingClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                        <Button Content="Probe PropertyGrid" Click="LeakProbe_OnPropertyGridClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
                                     </StackPanel>
+
+                                    <!-- Transient host for the main-window-control and PropertyGrid probes. They
+                                         briefly parent a real control here (long-lived main window tree), then
+                                         detach it - mirrors a main-frame-nav editor, which collects cleanly. -->
+                                    <Border x:Name="LeakProbe_MainHostArea" Height="140" Margin="0,4,0,0"/>
+
+                                    <Grid Margin="0,8,0,0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <TextBlock Grid.Column="0" Text="Output" VerticalAlignment="Center" Style="{ThemeResource BodyStrongTextBlockStyle}"/>
+                                        <Button Grid.Column="1" Content="Copy to clipboard" Click="LeakProbe_OnCopyOutputClicked" Margin="0,0,8,0"/>
+                                        <Button Grid.Column="2" Content="Clear" Click="LeakProbe_OnClearOutputClicked"/>
+                                    </Grid>
+                                    <TextBox x:Name="LeakProbe_Output"
+                                             IsReadOnly="True"
+                                             AcceptsReturn="True"
+                                             TextWrapping="Wrap"
+                                             IsSpellCheckEnabled="False"
+                                             FontFamily="Consolas"
+                                             FontSize="12"
+                                             Height="240"
+                                             ScrollViewer.VerticalScrollBarVisibility="Auto"
+                                             ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                                             Text=""/>
 
                                     <TextBlock Text="Notes" Style="{ThemeResource BodyStrongTextBlockStyle}" Margin="0,8,0,0"/>
                                     <TextBlock TextWrapping="Wrap" Opacity="0.7" FontSize="12"

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -306,6 +306,19 @@
                                                 <TextBlock x:Name="EnumBugReproStatus" VerticalAlignment="Center" Opacity="0.7"/>
                                             </StackPanel>
                                         </StackPanel>
+
+                                        <!-- Bug repro: SelectionChanged must fire on every standalone deselect -->
+                                        <StackPanel Spacing="4" Margin="0,12,0,0">
+                                            <TextBlock Text="SelectionChanged on deselect (repro)" FontSize="11" Opacity="0.7"/>
+                                            <TextBlock Text="Multi-select: select two, click one off - the counter must tick. Single-select + allow-none: select one, click it off to empty - the counter must tick there too. Both strips share the one counter." TextWrapping="Wrap" FontSize="11" Opacity="0.5"/>
+                                            <ajut:ToggleStrip x:Name="ToggleStripSelectionChangedRepro"
+                                                              AllowMultiSelect="True" AllowNoSelection="True"
+                                                              SelectionChanged="ToggleStripSelectionChangedRepro_OnSelectionChanged"/>
+                                            <ajut:ToggleStrip x:Name="ToggleStripSingleSelectNoneRepro"
+                                                              AllowNoSelection="True"
+                                                              SelectionChanged="ToggleStripSelectionChangedRepro_OnSelectionChanged"/>
+                                            <TextBlock x:Name="ToggleStripSelectionChangedStatus" Opacity="0.8" Text="SelectionChanged fired 0 times"/>
+                                        </StackPanel>
                                     </StackPanel>
 
                                     <TextBlock Text="EnumToggleStrip" Style="{ThemeResource SubtitleTextBlockStyle}" Margin="0,12,0,0"/>

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -905,18 +905,41 @@ namespace AJutShowRoomWinUI
             }
         }
 
-        // Deterministic collect: pump the dispatcher between full GC passes so any WinUI cleanup
-        // deferred to the message loop (unload finalization, container recycling) runs before the
-        // next pass. Without the pump, a single synchronous GC burst races that deferred work.
+        // Deterministic collect: drain the dispatcher, then run a full GC, repeated. The drain
+        // matters because some controls defer work via DispatcherQueue.TryEnqueue that captures
+        // data we are measuring - e.g. PropertyGridItemRow.OnDataContextChanged enqueues a
+        // (Normal-priority) ApplyEditorContent callback capturing the edit target -> source. Those
+        // are self-cleaning once they run, but if still queued at GC time they pin what they
+        // captured. Awaiting a Low-priority enqueue returns only after every higher-priority
+        // queued callback has run, so the captures are gone before we measure.
         private static async Task LeakProbe_SettleAndCollectAsync ()
         {
-            for (int i = 0; i < 4; ++i)
+            for (int i = 0; i < 6; ++i)
             {
+                await LeakProbe_DrainDispatcherAsync();
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
                 GC.Collect();
                 await Task.Delay(100);
             }
+        }
+
+        // Completes only after all higher-priority dispatcher work has run (Low runs last).
+        private static Task LeakProbe_DrainDispatcherAsync ()
+        {
+            var done = new TaskCompletionSource();
+            var queue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
+            bool enqueued = queue != null && queue.TryEnqueue(
+                Microsoft.UI.Dispatching.DispatcherQueuePriority.Low,
+                () => done.SetResult()
+            );
+
+            if (!enqueued)
+            {
+                done.SetResult();
+            }
+
+            return done.Task;
         }
 
         private static int LeakProbe_CountDescendants<T> (DependencyObject root) where T : DependencyObject
@@ -1469,6 +1492,28 @@ namespace AJutShowRoomWinUI
             new ShowRoomSubObject { SubObjValue = 99 },
         };
 
+        // ------ PGList element header demo ------
+        // Plain complex-element lists (no elevation, no custom editor), so each element row is expandable
+        // with an otherwise-blank value column. ElementDisplayMemberName fills that column with the
+        // element's Name. The first list shows the header in every state (Always); the second only while
+        // the element row is collapsed (WhenCollapsed).
+        [PGList(ElementDisplayMemberName = nameof(RosterEntry.Name))]
+        [PGGroup("Lists")]
+        public List<RosterEntry> Roster { get; set; } = new List<RosterEntry>
+        {
+            new RosterEntry { Name = "Tony", Age = 16 },
+            new RosterEntry { Name = "Jill", Age = 24 },
+            new RosterEntry { Name = "Jessup", Age = 31 },
+        };
+
+        [PGList(ElementDisplayMemberName = nameof(RosterEntry.Name), ElementDisplayMemberVisibility = eElementHeaderDisplay.WhenCollapsed)]
+        [PGGroup("Lists")]
+        public List<RosterEntry> RosterCollapsedHeaders { get; set; } = new List<RosterEntry>
+        {
+            new RosterEntry { Name = "Avery", Age = 19 },
+            new RosterEntry { Name = "Blake", Age = 27 },
+        };
+
         private class ColorToStringConverter : PropertyGridTypeAliasing<Color, string>
         {
             public override Type AliasType => typeof(string);
@@ -1497,6 +1542,25 @@ namespace AJutShowRoomWinUI
         {
             get => m_subObjValue;
             set => this.SetAndRaiseIfChanged(ref m_subObjValue, value);
+        }
+    }
+
+    // Element type for the PGList element-header demo - a plain complex object with a couple of
+    // editable properties so the element rows expand and the value column is otherwise empty.
+    public class RosterEntry : NotifyPropertyChanged
+    {
+        private string m_name;
+        public string Name
+        {
+            get => m_name;
+            set => this.SetAndRaiseIfChanged(ref m_name, value);
+        }
+
+        private int m_age;
+        public int Age
+        {
+            get => m_age;
+            set => this.SetAndRaiseIfChanged(ref m_age, value);
         }
     }
 

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -29,6 +29,7 @@ namespace AJutShowRoomWinUI
     {
         private const string kThemeColorsSettingsKey = "_Hidden_theme_colors";
         private readonly ObservableCollection<string> m_themeColorResolver = new ObservableCollection<string>();
+        private int m_selectionChangedReproCount;
 
         // ===========[ Dock Zone test state ]============================================
         private DockingManager m_dockingManager;
@@ -57,6 +58,10 @@ namespace AJutShowRoomWinUI
 
             // ToggleStrip enum bug repro
             this.ToggleStripEnumBugRepro.ItemsSource = Enum.GetValues<eEditorMode>();
+
+            // ToggleStrip SelectionChanged deselect repros (multi-select + single-select-with-none, shared counter)
+            this.ToggleStripSelectionChangedRepro.ItemsSource = new[] { "One", "Two", "Three", "Four" };
+            this.ToggleStripSingleSelectNoneRepro.ItemsSource = new[] { "One", "Two", "Three" };
 
             this.StockBumpStackDemos();
 
@@ -149,6 +154,13 @@ namespace AJutShowRoomWinUI
             this.SelectedEditorMode = eEditorMode.Text;
             this.ToggleStripEnumBugRepro.SelectedItem = eEditorMode.Text;
             this.EnumBugReproStatus.Text = $"Set to Text. SelectedItem = {this.ToggleStripEnumBugRepro.SelectedItem}";
+        }
+
+        private void ToggleStripSelectionChangedRepro_OnSelectionChanged (object sender, AJut.UX.Controls.ToggleStrip.ToggleStripSelectionChangedEventArgs e)
+        {
+            ++m_selectionChangedReproCount;
+            string current = string.Join(", ", e.CurrentSelection.OfType<object>());
+            this.ToggleStripSelectionChangedStatus.Text = $"SelectionChanged fired {m_selectionChangedReproCount} times - current: [{current}]";
         }
 
         private void AddThemeColor(string themeColor)

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -533,25 +533,22 @@ namespace AJutShowRoomWinUI
 
         private void LeakProbe_OnDockingManagerClicked (object sender, RoutedEventArgs e)
         {
-            this.LeakProbe_DockingManagerStatus.Text = "running...";
             bool collected = LeakProbe_BuildAndDisposeDockingManager(this);
-            this.LeakProbe_DockingManagerStatus.Text = collected
+            this.LeakProbe_AppendOutput("Probe DockingManager", collected
                 ? "PASS - DockingManager was collected after Dispose"
-                : "FAIL - DockingManager survived Dispose + GC (something is still pinning it)";
+                : "FAIL - DockingManager survived Dispose + GC (something is still pinning it)");
         }
 
         private void LeakProbe_OnWindowManagerClicked (object sender, RoutedEventArgs e)
         {
-            this.LeakProbe_WindowManagerStatus.Text = "running...";
             bool collected = LeakProbe_BuildAndDisposeWindowManager(this);
-            this.LeakProbe_WindowManagerStatus.Text = collected
+            this.LeakProbe_AppendOutput("Probe WindowManager", collected
                 ? "PASS - WindowManager was collected after Dispose"
-                : "FAIL - WindowManager survived Dispose + GC (something is still pinning it)";
+                : "FAIL - WindowManager survived Dispose + GC (something is still pinning it)");
         }
 
         private void LeakProbe_OnCycleClicked (object sender, RoutedEventArgs e)
         {
-            this.LeakProbe_CycleStatus.Text = "running...";
             int passes = 0;
             for (int i = 0; i < 5; ++i)
             {
@@ -561,9 +558,9 @@ namespace AJutShowRoomWinUI
                 }
             }
 
-            this.LeakProbe_CycleStatus.Text = passes == 5
+            this.LeakProbe_AppendOutput("Probe x5 (open/close cycles)", passes == 5
                 ? "PASS - all 5 cycles collected cleanly"
-                : $"FAIL - only {passes}/5 cycles collected (later iterations should still pass if the first one does)";
+                : $"FAIL - only {passes}/5 cycles collected (later iterations should still pass if the first one does)");
         }
 
         // Build a real DockingManager against the live root window, dispose it, drop the
@@ -611,6 +608,471 @@ namespace AJutShowRoomWinUI
             }
 
             return !weak.IsAlive;
+        }
+
+        // ===========[ Leak Probe - Docking host scenario ]==============================
+        // Models the ARC-56 residual: an editor whose layout is a DockingManager lives inside
+        // a transient child Window's Frame, while the manager's RootWindow is the long-lived
+        // main window. After the child window closes and the manager is disposed, the dock
+        // zone, docked panels, and anything bound to the editor page must all collect. The
+        // main-window variant is the control case - hosting the same graph in the main window
+        // tree, which the prior m_dockZoneMapping fix already collects cleanly.
+
+        private async void LeakProbe_OnChildWindowDockingClicked (object sender, RoutedEventArgs e)
+        {
+            const int kCycles = 4;
+            var button = sender as Button;
+            if (button != null) { button.IsEnabled = false; }
+            try
+            {
+                var weaks = new List<DockingLeakProbeWeaks>();
+                for (int i = 0; i < kCycles; ++i)
+                {
+                    var probe = LeakProbe_BuildChildWindowDocking(this);
+
+                    // Wait until the page actually loads so the dock layout realizes (template ->
+                    // drop overlay + DockLeafLayout). Without this we may measure a window that
+                    // closed before it ever built anything - a vacuous pass. builtLeaves in the
+                    // report proves the structure was really there.
+                    await LeakProbe_WaitForLoaded(probe.EditorPage, 3000);
+                    await Task.Delay(200);
+
+                    int leaves = LeakProbe_CountDescendants<AJut.UX.Controls.DockLeafLayout>(probe.RootZone);
+
+                    // Hold a watch handle to the page so we can wait for its real unload after
+                    // teardown nulls every probe-held strong ref.
+                    FrameworkElement pageWatch = probe.EditorPage;
+
+                    var weak = LeakProbe_TeardownDockingProbe(probe);
+                    weak.BuiltLeaves = leaves;
+                    weaks.Add(weak);
+                    probe = null;
+
+                    // Deterministic read: wait for WinUI to actually unload the page (it releases
+                    // native / container refs during the Unloaded pass), then let deferred cleanup
+                    // run, before we collect and measure.
+                    await LeakProbe_WaitForUnloaded(pageWatch, 3000);
+                    pageWatch = null;
+                    await Task.Delay(150);
+                }
+
+                await LeakProbe_SettleAndCollectAsync();
+                this.LeakProbe_AppendOutput("Dock leak - child window", LeakProbe_ReportSurvivors(weaks));
+            }
+            finally
+            {
+                if (button != null) { button.IsEnabled = true; }
+            }
+        }
+
+        private async void LeakProbe_OnMainWindowDockingClicked (object sender, RoutedEventArgs e)
+        {
+            const int kCycles = 4;
+            var button = sender as Button;
+            if (button != null) { button.IsEnabled = false; }
+            try
+            {
+                var weaks = new List<DockingLeakProbeWeaks>();
+                for (int i = 0; i < kCycles; ++i)
+                {
+                    var probe = this.LeakProbe_BuildMainWindowDocking();
+
+                    await LeakProbe_WaitForLoaded(probe.EditorPage, 3000);
+                    await Task.Delay(200);
+
+                    int leaves = LeakProbe_CountDescendants<AJut.UX.Controls.DockLeafLayout>(probe.RootZone);
+
+                    FrameworkElement pageWatch = probe.EditorPage;
+
+                    var weak = LeakProbe_TeardownDockingProbe(probe);
+                    weak.BuiltLeaves = leaves;
+                    weaks.Add(weak);
+                    probe = null;
+
+                    await LeakProbe_WaitForUnloaded(pageWatch, 3000);
+                    pageWatch = null;
+                    await Task.Delay(150);
+                }
+
+                await LeakProbe_SettleAndCollectAsync();
+                this.LeakProbe_AppendOutput("Dock leak - main window (control)", LeakProbe_ReportSurvivors(weaks));
+            }
+            finally
+            {
+                if (button != null) { button.IsEnabled = true; }
+            }
+        }
+
+        // Builds the docking graph inside a fresh child Window (RootWindow stays the main window).
+        private static DockingLeakProbe LeakProbe_BuildChildWindowDocking (Window mainRoot)
+        {
+            var childWindow = new Window();
+            var frame = new Frame();
+            var editorPage = LeakProbe_BuildEditorPageStandin(out var rootZone);
+
+            frame.Content = editorPage;
+            childWindow.Content = frame;
+            childWindow.Activate();
+
+            var probe = LeakProbe_StockDockingGraph(mainRoot, rootZone, editorPage);
+            probe.ChildWindow = childWindow;
+            probe.Frame = frame;
+            probe.EditorPage = editorPage;
+            return probe;
+        }
+
+        // Builds the same docking graph but hosts it in the main window's own visual tree.
+        private DockingLeakProbe LeakProbe_BuildMainWindowDocking ()
+        {
+            var frame = new Frame();
+            var editorPage = LeakProbe_BuildEditorPageStandin(out var rootZone);
+
+            frame.Content = editorPage;
+            this.LeakProbe_MainHostArea.Child = frame;
+
+            var probe = LeakProbe_StockDockingGraph(this, rootZone, editorPage);
+            probe.Frame = frame;
+            probe.EditorPage = editorPage;
+            probe.MainHost = this.LeakProbe_MainHostArea;
+            return probe;
+        }
+
+        // The editor "page" stand-in: a ContentControl whose content is the root DockZone,
+        // mirroring an editor Page whose layout root is an AJut dock zone.
+        private static FrameworkElement LeakProbe_BuildEditorPageStandin (out AJut.UX.Controls.DockZone rootZone)
+        {
+            rootZone = new AJut.UX.Controls.DockZone { Name = "LeakProbeRootZone" };
+            return new ContentControl
+            {
+                HorizontalContentAlignment = HorizontalAlignment.Stretch,
+                VerticalContentAlignment = VerticalAlignment.Stretch,
+                Content = rootZone,
+            };
+        }
+
+        // Stands up a DockingManager against the given root window, registers the zone, docks a
+        // couple of panels, and binds one panel back to the editor page (page as binding Source)
+        // so a surviving panel pins the page exactly the way the real consumer's editor does.
+        private static DockingLeakProbe LeakProbe_StockDockingGraph (Window root, AJut.UX.Controls.DockZone rootZone, FrameworkElement editorPage)
+        {
+            var manager = new DockingManager(root, "dock-leak-" + Guid.NewGuid().ToString("N"));
+            manager.RegisterDisplayFactory<ShowRoomPanel>();
+            manager.RegisterMainWindowRootDockZones(rootZone);
+
+            ShowRoomPanel panelA = null;
+            ShowRoomPanel panelB = null;
+
+            var zone = manager.FindFirstAvailableDockZone();
+            if (zone != null)
+            {
+                panelA = manager.DockNewPanel<ShowRoomPanel>(zone);
+                panelA.Label = "Leak A";
+                panelA.DockingAdapter.TitleContent = "Leak A";
+
+                panelB = manager.DockNewPanel<ShowRoomPanel>(zone);
+                panelB.Label = "Leak B";
+                panelB.DockingAdapter.TitleContent = "Leak B";
+            }
+
+            // Bind a docked panel with the editor page as the binding Source. WinUI keeps a
+            // binding's Source alive while the target lives, so a surviving panel keeps the page.
+            if (panelA != null)
+            {
+                panelA.SetBinding(FrameworkElement.TagProperty, new Microsoft.UI.Xaml.Data.Binding { Source = editorPage });
+            }
+
+            return new DockingLeakProbe
+            {
+                Manager = manager,
+                RootZone = rootZone,
+                PanelA = panelA,
+                PanelB = panelB,
+            };
+        }
+
+        // Drives the app-side teardown (manager.Dispose + content null-out + window close),
+        // snapshots weak references to every node that must collect, then drops all strong refs.
+        private static DockingLeakProbeWeaks LeakProbe_TeardownDockingProbe (DockingLeakProbe probe)
+        {
+            probe.Manager.Dispose();
+
+            if (probe.Frame != null)
+            {
+                probe.Frame.Content = null;
+            }
+
+            if (probe.EditorPage is ContentControl pageContent)
+            {
+                pageContent.Content = null;
+            }
+
+            if (probe.MainHost != null)
+            {
+                probe.MainHost.Child = null;
+            }
+
+            if (probe.ChildWindow != null)
+            {
+                probe.ChildWindow.Content = null;
+                probe.ChildWindow.Close();
+            }
+
+            var weaks = new DockingLeakProbeWeaks
+            {
+                RootZone = new WeakReference(probe.RootZone),
+                PanelA = probe.PanelA != null ? new WeakReference(probe.PanelA) : null,
+                EditorPage = new WeakReference(probe.EditorPage),
+                ChildWindow = probe.ChildWindow != null ? new WeakReference(probe.ChildWindow) : null,
+            };
+
+            // Drop every strong reference the probe holds so the only remaining handles are weak.
+            probe.Manager = null;
+            probe.RootZone = null;
+            probe.PanelA = null;
+            probe.PanelB = null;
+            probe.EditorPage = null;
+            probe.Frame = null;
+            probe.MainHost = null;
+            probe.ChildWindow = null;
+
+            return weaks;
+        }
+
+        // Polls IsLoaded rather than subscribing Loaded (no anonymous handler, and re-entrant safe).
+        private static async Task LeakProbe_WaitForLoaded (FrameworkElement element, int timeoutMs)
+        {
+            int waited = 0;
+            while (element != null && !element.IsLoaded && waited < timeoutMs)
+            {
+                await Task.Delay(50);
+                waited += 50;
+            }
+        }
+
+        // Waits for the element to actually leave the live tree. WinUI releases its native /
+        // item-container references during the Unloaded pass (a later dispatcher tick), not at
+        // the moment we detach - so measuring before this completes reads a still-pinned element
+        // that would collect a beat later (the source of the flaky reads).
+        private static async Task LeakProbe_WaitForUnloaded (FrameworkElement element, int timeoutMs)
+        {
+            int waited = 0;
+            while (element != null && element.IsLoaded && waited < timeoutMs)
+            {
+                await Task.Delay(50);
+                waited += 50;
+            }
+        }
+
+        // Deterministic collect: pump the dispatcher between full GC passes so any WinUI cleanup
+        // deferred to the message loop (unload finalization, container recycling) runs before the
+        // next pass. Without the pump, a single synchronous GC burst races that deferred work.
+        private static async Task LeakProbe_SettleAndCollectAsync ()
+        {
+            for (int i = 0; i < 4; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                await Task.Delay(100);
+            }
+        }
+
+        private static int LeakProbe_CountDescendants<T> (DependencyObject root) where T : DependencyObject
+        {
+            if (root == null)
+            {
+                return 0;
+            }
+
+            int count = root is T ? 1 : 0;
+            int childCount = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < childCount; ++i)
+            {
+                count += LeakProbe_CountDescendants<T>(VisualTreeHelper.GetChild(root, i));
+            }
+
+            return count;
+        }
+
+        // Counts only - the GC happens in LeakProbe_SettleAndCollectAsync before this is called.
+        private static string LeakProbe_ReportSurvivors (List<DockingLeakProbeWeaks> weaks)
+        {
+            int zones = 0;
+            int panels = 0;
+            int pages = 0;
+            int windows = 0;
+            int builtLeaves = 0;
+            foreach (var w in weaks)
+            {
+                if (w.RootZone.IsAlive) { ++zones; }
+                if (w.PanelA != null && w.PanelA.IsAlive) { ++panels; }
+                if (w.EditorPage.IsAlive) { ++pages; }
+                if (w.ChildWindow != null && w.ChildWindow.IsAlive) { ++windows; }
+                builtLeaves += w.BuiltLeaves;
+            }
+
+            // windows is informational only - WinUI is known to keep a closed Window alive a
+            // while; the dock leak is zones/panels/pages surviving past Dispose. builtLeaves
+            // proves the dock structure actually realized - builtLeaves=0 means a vacuous run.
+            bool leaked = zones > 0 || panels > 0 || pages > 0;
+            string detail = $"zones={zones}/{weaks.Count} panels={panels}/{weaks.Count} pages={pages}/{weaks.Count} windows={windows}/{weaks.Count} builtLeaves={builtLeaves}";
+            if (builtLeaves == 0)
+            {
+                return $"INCONCLUSIVE - dock layout never realized (builtLeaves=0): {detail}";
+            }
+
+            return leaked
+                ? $"FAIL - survivors after GC: {detail}"
+                : $"PASS - all collected ({detail})";
+        }
+
+        // ===========[ Leak Probe - Output ]=============================================
+        // Every probe routes its result here. Newest entry is prepended so the latest run
+        // is always visible at the top without scrolling.
+
+        private void LeakProbe_AppendOutput (string title, string body)
+        {
+            string stamp = DateTime.Now.ToString("HH:mm:ss");
+            string entry = $"[{stamp}] {title}\n    {body}";
+            this.LeakProbe_Output.Text = this.LeakProbe_Output.Text.Length == 0
+                ? entry
+                : entry + "\n\n" + this.LeakProbe_Output.Text;
+        }
+
+        private void LeakProbe_OnCopyOutputClicked (object sender, RoutedEventArgs e)
+        {
+            var package = new Windows.ApplicationModel.DataTransfer.DataPackage();
+            package.SetText(this.LeakProbe_Output.Text ?? string.Empty);
+            Windows.ApplicationModel.DataTransfer.Clipboard.SetContent(package);
+        }
+
+        private void LeakProbe_OnClearOutputClicked (object sender, RoutedEventArgs e)
+        {
+            this.LeakProbe_Output.Text = string.Empty;
+        }
+
+        // ===========[ Leak Probe - PropertyGrid ]=======================================
+        // Builds a PropertyGrid against a fresh source object in the main window's tree,
+        // lets it discover + render the source's properties, then disposes it and checks
+        // that both the grid and the source object collect. A surviving source means the
+        // grid (or its manager / row tree) is holding a reference past Dispose.
+
+        private async void LeakProbe_OnPropertyGridClicked (object sender, RoutedEventArgs e)
+        {
+            const int kCycles = 4;
+            var button = sender as Button;
+            if (button != null) { button.IsEnabled = false; }
+            try
+            {
+                var weaks = new List<PropertyGridLeakProbeWeaks>();
+                for (int i = 0; i < kCycles; ++i)
+                {
+                    var probe = this.LeakProbe_BuildPropertyGrid();
+
+                    // Let the grid load + apply its template and build its property-row tree.
+                    await LeakProbe_WaitForLoaded(probe.Grid, 3000);
+                    await Task.Delay(300);
+
+                    FrameworkElement gridWatch = probe.Grid;
+
+                    weaks.Add(LeakProbe_TeardownPropertyGrid(probe, this.LeakProbe_MainHostArea));
+                    probe = null;
+
+                    // Deterministic read: wait for the grid to actually unload, then let deferred
+                    // WinUI cleanup run, before collecting.
+                    await LeakProbe_WaitForUnloaded(gridWatch, 3000);
+                    gridWatch = null;
+                    await Task.Delay(150);
+                }
+
+                await LeakProbe_SettleAndCollectAsync();
+                this.LeakProbe_AppendOutput("Probe PropertyGrid", LeakProbe_ReportPropertyGridSurvivors(weaks));
+            }
+            finally
+            {
+                if (button != null) { button.IsEnabled = true; }
+            }
+        }
+
+        private PropertyGridLeakProbe LeakProbe_BuildPropertyGrid ()
+        {
+            var grid = new AJut.UX.Controls.PropertyGrid();
+            var source = new ShowRoomAlpha();
+            grid.SingleItemSource = source;
+            this.LeakProbe_MainHostArea.Child = grid;
+
+            return new PropertyGridLeakProbe
+            {
+                Grid = grid,
+                Source = source,
+            };
+        }
+
+        private static PropertyGridLeakProbeWeaks LeakProbe_TeardownPropertyGrid (PropertyGridLeakProbe probe, Border host)
+        {
+            probe.Grid.Dispose();
+            host.Child = null;
+
+            var weaks = new PropertyGridLeakProbeWeaks
+            {
+                Grid = new WeakReference(probe.Grid),
+                Source = new WeakReference(probe.Source),
+            };
+
+            probe.Grid = null;
+            probe.Source = null;
+            return weaks;
+        }
+
+        // Counts only - the GC happens in LeakProbe_SettleAndCollectAsync before this is called.
+        private static string LeakProbe_ReportPropertyGridSurvivors (List<PropertyGridLeakProbeWeaks> weaks)
+        {
+            int grids = 0;
+            int sources = 0;
+            foreach (var w in weaks)
+            {
+                if (w.Grid.IsAlive) { ++grids; }
+                if (w.Source.IsAlive) { ++sources; }
+            }
+
+            bool leaked = grids > 0 || sources > 0;
+            string detail = $"grids={grids}/{weaks.Count} sources={sources}/{weaks.Count}";
+            return leaked
+                ? $"FAIL - survivors after GC: {detail}"
+                : $"PASS - all collected ({detail})";
+        }
+
+        private sealed class DockingLeakProbe
+        {
+            public DockingManager Manager { get; set; }
+            public AJut.UX.Controls.DockZone RootZone { get; set; }
+            public ShowRoomPanel PanelA { get; set; }
+            public ShowRoomPanel PanelB { get; set; }
+            public FrameworkElement EditorPage { get; set; }
+            public Frame Frame { get; set; }
+            public Border MainHost { get; set; }
+            public Window ChildWindow { get; set; }
+        }
+
+        private sealed class DockingLeakProbeWeaks
+        {
+            public WeakReference RootZone { get; set; }
+            public WeakReference PanelA { get; set; }
+            public WeakReference EditorPage { get; set; }
+            public WeakReference ChildWindow { get; set; }
+            public int BuiltLeaves { get; set; }
+        }
+
+        private sealed class PropertyGridLeakProbe
+        {
+            public AJut.UX.Controls.PropertyGrid Grid { get; set; }
+            public object Source { get; set; }
+        }
+
+        private sealed class PropertyGridLeakProbeWeaks
+        {
+            public WeakReference Grid { get; set; }
+            public WeakReference Source { get; set; }
         }
     }
 

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -43,6 +43,7 @@ namespace AJutShowRoomWinUI
             this.InitializeComponent();
             this.Root.SetupFor(this);
             this.TestPropertyGrid.PropertyTreeChanged += this.TestPropertyGrid_OnPropertyTreeChanged;
+            this.TestPropertyGrid.SelectedSourceObjectChanged += this.TestPropertyGrid_OnSelectedSourceObjectChanged;
             this.SetPGSource(m_alphaObj);
 
             // ToggleStrip demo items
@@ -333,6 +334,9 @@ namespace AJutShowRoomWinUI
             m_currentPGTestObj = obj;
             this.TestPropertyGrid.SingleItemSource = obj;
             this.ResetJsonDisplay();
+
+            // Swapping the source rebuilds the tree and drops any selection - reset the readout to match.
+            this.PGSelectionReadout.Text = "(none)";
         }
 
         private void PGSource_OnAlphaClicked (object sender, RoutedEventArgs e) => this.SetPGSource(m_alphaObj);
@@ -440,6 +444,44 @@ namespace AJutShowRoomWinUI
         private void TestPropertyGrid_OnPropertyTreeChanged(object sender, EventArgs e)
         {
             this.ResetJsonDisplay();
+        }
+
+        // ------ Selection-surface tester wiring ------
+        private void TestPropertyGrid_OnSelectedSourceObjectChanged (object sender, EventArgs e)
+        {
+            this.UpdatePGSelectionReadout();
+        }
+
+        private void UpdatePGSelectionReadout ()
+        {
+            object selected = this.TestPropertyGrid.SelectedSourceObject;
+            this.PGSelectionReadout.Text = selected is ShowRoomSubObject sub
+                ? $"ShowRoomSubObject (SubObjValue={sub.SubObjValue})"
+                : selected?.ToString() ?? "(none)";
+        }
+
+        private void PGSelect_OnRandomElementClicked (object sender, RoutedEventArgs e)
+        {
+            // Complex A/B carry ListWithElevation (complex elements with identity). Selecting one by
+            // reference drives the programmatic selection path - the one that hit the Single-mode
+            // SelectedItems COMException, and (when the list node is collapsed) the expand-then-select path.
+            if (this.TestPropertyGrid.SingleItemSource is ShowRoomTester tester && tester.ListWithElevation.Count > 0)
+            {
+                ShowRoomSubObject element = tester.ListWithElevation[new Random().Next(0, tester.ListWithElevation.Count)];
+                if (!this.TestPropertyGrid.TrySelectSourceObject(element))
+                {
+                    this.PGSelectionReadout.Text = "(could not find a row for that element)";
+                }
+            }
+            else
+            {
+                this.PGSelectionReadout.Text = "(switch to Complex A or B - it has the element list)";
+            }
+        }
+
+        private void PGSelect_OnClearClicked (object sender, RoutedEventArgs e)
+        {
+            this.TestPropertyGrid.SelectedTarget = null;
         }
         private void ResetJsonDisplay()
         {

--- a/sandbox/wpf/UI/Controls/PropertyGridControlExample.xaml
+++ b/sandbox/wpf/UI/Controls/PropertyGridControlExample.xaml
@@ -11,55 +11,69 @@
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800"
              x:Name="Self">
-    <ajut:AutoGrid FixedRowCount="1">
-        <ajut:PropertyGrid Grid.Column="1" BorderThickness="3" BorderBrush="#202020" Margin="20" Background="#1000" HorizontalContentAlignment="Stretch"
+    <DockPanel>
+        <!-- Selection-surface tester: exercises the PropertyGrid selection API (SelectedSourceObject /
+             SelectedSourceObjectChanged / TrySelectSourceObject) added for surfacing list-element selection. -->
+        <Border DockPanel.Dock="Top" Background="#18000000" Padding="8" Margin="0,0,0,4">
+            <StackPanel Orientation="Horizontal">
+                <TextBlock Text="Selection test:" FontWeight="Bold" VerticalAlignment="Center" Margin="0,0,8,0"/>
+                <Button Content="Select random toy" Click="SelectRandomToy_OnClick"
+                        ToolTip="Calls PropertyGrid.TrySelectSourceObject on a random Toys element - exercises programmatic select + scroll-into-view (and the collapsed-target path)"/>
+                <Button Content="Clear selection" Click="ClearSelection_OnClick" Margin="6,0,0,0"/>
+                <TextBlock Text="SelectedSourceObject:" VerticalAlignment="Center" Margin="16,0,6,0"/>
+                <TextBlock x:Name="SelectedSourceReadout" Text="(none)" FontWeight="Bold" VerticalAlignment="Center"/>
+            </StackPanel>
+        </Border>
+        <ajut:AutoGrid FixedRowCount="1">
+            <ajut:PropertyGrid x:Name="PropGrid" Grid.Column="1" BorderThickness="3" BorderBrush="{DynamicResource AJut_Brush_BorderCommon}" Margin="20" Background="#1000" HorizontalContentAlignment="Stretch"
                            SingleItemSource="{Binding ElementName=PropGridSelectionOptions, Path=SelectedItem}"
                            LabelColumnWidth="140"
                            PropertyToolTipPlacement="PropertyNameAndValue"
                            >
-            <ajut:PropertyGrid.ItemTemplateSelector>
-                <ajut:PropertyGridTemplateSelector>
-                    <ajut:PropertyGridTemplateSelector.RegisteredTemplates>
-                        <DataTemplate x:Key="Text" DataType="{x:Type ajprop:PropertyEditTarget}">
-                            <ajut:EditableTextBlock Text="{Binding Path=EditValue, Mode=TwoWay}" FontSize="16"/>
-                        </DataTemplate>
-                        <DataTemplate x:Key="Number" DataType="{x:Type ajprop:PropertyEditTarget}">
-                            <ajut:NumericEditor Value="{Binding Path=EditValue, Mode=TwoWay}"
+                <ajut:PropertyGrid.ItemTemplateSelector>
+                    <ajut:PropertyGridTemplateSelector>
+                        <ajut:PropertyGridTemplateSelector.RegisteredTemplates>
+                            <DataTemplate x:Key="Text" DataType="{x:Type ajprop:PropertyEditTarget}">
+                                <ajut:EditableTextBlock Text="{Binding Path=EditValue, Mode=TwoWay}" FontSize="16"/>
+                            </DataTemplate>
+                            <DataTemplate x:Key="Number" DataType="{x:Type ajprop:PropertyEditTarget}">
+                                <ajut:NumericEditor Value="{Binding Path=EditValue, Mode=TwoWay}"
                                                 Minimum="{Binding Path=EditContext.Minimum, FallbackValue=0}"
                                                 Maximum="{Binding Path=EditContext.Maximum, FallbackValue=100}"
                                                 NumberTextAlignment="Left"/>
-                        </DataTemplate>
-                        <DataTemplate x:Key="SavePath" DataType="{x:Type ajprop:PropertyEditTarget}">
-                            <ajut:PathSelectionControl SelectedPath="{Binding Path=EditValue}"/>
-                        </DataTemplate>
-                    </ajut:PropertyGridTemplateSelector.RegisteredTemplates>
-                    <ajut:PropertyGridTemplateSelector.Default>
-                        <DataTemplate DataType="{x:Type ajprop:PropertyEditTarget}">
-                            <TextBlock Text="{Binding Path=EditValue}"/>
-                        </DataTemplate>
-                    </ajut:PropertyGridTemplateSelector.Default>
-                </ajut:PropertyGridTemplateSelector>
+                            </DataTemplate>
+                            <DataTemplate x:Key="SavePath" DataType="{x:Type ajprop:PropertyEditTarget}">
+                                <ajut:PathSelectionControl SelectedPath="{Binding Path=EditValue}"/>
+                            </DataTemplate>
+                        </ajut:PropertyGridTemplateSelector.RegisteredTemplates>
+                        <ajut:PropertyGridTemplateSelector.Default>
+                            <DataTemplate DataType="{x:Type ajprop:PropertyEditTarget}">
+                                <TextBlock Text="{Binding Path=EditValue}"/>
+                            </DataTemplate>
+                        </ajut:PropertyGridTemplateSelector.Default>
+                    </ajut:PropertyGridTemplateSelector>
 
-            </ajut:PropertyGrid.ItemTemplateSelector>
-        </ajut:PropertyGrid>
-        <ListBox x:Name="PropGridSelectionOptions" Grid.Column="1" SelectedIndex="0"
+                </ajut:PropertyGrid.ItemTemplateSelector>
+            </ajut:PropertyGrid>
+            <ListBox x:Name="PropGridSelectionOptions" Grid.Column="1" SelectedIndex="0"
                  ItemsSource="{Binding ElementName=Self, Path=PropertyGridItems}">
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <StackPanel Orientation="Horizontal">
-                        <TextBlock>
-                            <TextBlock.Inlines>
-                                <Run Text="{Binding Path=DogsName}"/>
-                                <Run Text=": "/>
-                                <Run Text="{Binding Path=DogsAge}"/>
-                            </TextBlock.Inlines>
-                        </TextBlock>
-                        <Button Content="Set age" Click="SetDogAge_OnClick"/>
-                        <Button Content="Set speed" Click="SetElevatedTopSpeed_OnClick"
-                                ToolTip="Sets elevated TopSpeed externally - tests RecacheEditValue cascade"/>
-                    </StackPanel>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-    </ajut:AutoGrid>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <TextBlock>
+                                <TextBlock.Inlines>
+                                    <Run Text="{Binding Path=DogsName}"/>
+                                    <Run Text=": "/>
+                                    <Run Text="{Binding Path=DogsAge}"/>
+                                </TextBlock.Inlines>
+                            </TextBlock>
+                            <Button Content="Set age" Click="SetDogAge_OnClick"/>
+                            <Button Content="Set speed" Click="SetElevatedTopSpeed_OnClick"
+                                    ToolTip="Sets elevated TopSpeed externally - tests RecacheEditValue cascade"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+        </ajut:AutoGrid>
+    </DockPanel>
 </UserControl>

--- a/sandbox/wpf/UI/Controls/PropertyGridControlExample.xaml.cs
+++ b/sandbox/wpf/UI/Controls/PropertyGridControlExample.xaml.cs
@@ -22,6 +22,54 @@
                 new SelfAwarePropertyGridSource () { DogsName = "Bandit", DogsAge = 7 },
                 new SelfAwarePropertyGridSource () { DogsName = "Brosephina", DogsAge = 3 },
             };
+
+            this.Loaded += this.OnLoaded;
+            this.Unloaded += this.OnUnloaded;
+        }
+
+        // ------ Selection-surface tester wiring ------
+
+        private void OnLoaded (object sender, RoutedEventArgs e)
+        {
+            this.PropGrid.SelectedSourceObjectChanged -= this.OnSelectedSourceObjectChanged;
+            this.PropGrid.SelectedSourceObjectChanged += this.OnSelectedSourceObjectChanged;
+            this.UpdateSelectedSourceReadout();
+        }
+
+        private void OnUnloaded (object sender, RoutedEventArgs e)
+        {
+            this.PropGrid.SelectedSourceObjectChanged -= this.OnSelectedSourceObjectChanged;
+        }
+
+        private void OnSelectedSourceObjectChanged (object sender, EventArgs e)
+        {
+            this.UpdateSelectedSourceReadout();
+        }
+
+        private void UpdateSelectedSourceReadout ()
+        {
+            object selected = this.PropGrid.SelectedSourceObject;
+            this.SelectedSourceReadout.Text = selected?.ToString() ?? "(none)";
+        }
+
+        private void SelectRandomToy_OnClick (object sender, RoutedEventArgs e)
+        {
+            // Picks a Toys element off the currently-shown dog and selects its row by reference.
+            // Works whether the Toys node is expanded or collapsed (collapsed -> expands + scrolls to it).
+            if (this.PropGridSelectionOptions.SelectedItem is SelfAwarePropertyGridSource dog
+                && dog.Toys.Count > 0)
+            {
+                DogToy toy = dog.Toys[App.kRNG.Next(0, dog.Toys.Count)];
+                if (!this.PropGrid.TrySelectSourceObject(toy))
+                {
+                    this.SelectedSourceReadout.Text = $"(could not select {toy})";
+                }
+            }
+        }
+
+        private void ClearSelection_OnClick (object sender, RoutedEventArgs e)
+        {
+            this.PropGrid.SelectedTarget = null;
         }
 
         public static readonly DependencyProperty PropertyGridItemsProperty = DPUtils.Register(_ => _.PropertyGridItems);
@@ -48,6 +96,27 @@
         public string? OwnerName { get; set; } = "Unknown Owner";
         [PGEditor("Number")]
         public int OwnerAge { get; set; } = 30;
+    }
+
+    /// <summary>List element with stable identity - the selection tester resolves a selected row (the
+    /// element row or any of its sub-property rows) back to this exact instance via SelectedSourceObject.</summary>
+    public class DogToy : NotifyPropertyChanged
+    {
+        private string m_name;
+        public string Name
+        {
+            get => m_name;
+            set => this.SetAndRaiseIfChanged(ref m_name, value);
+        }
+
+        private bool m_isSqueaky;
+        public bool IsSqueaky
+        {
+            get => m_isSqueaky;
+            set => this.SetAndRaiseIfChanged(ref m_isSqueaky, value);
+        }
+
+        public override string ToString () => this.Name ?? "(toy)";
     }
 
     /// <summary>Sub-object for testing elevated child property recache.</summary>
@@ -181,6 +250,17 @@
         }
 
         // ------ PGList demos ------
+
+        // Complex-element list - each row is a DogToy with identity, so the selection tester can resolve
+        // a selected element (or sub-property) row back to the instance and select it programmatically.
+        [PGList]
+        [PGGroup("Lists")]
+        public List<DogToy> Toys { get; set; } = new List<DogToy>
+        {
+            new DogToy { Name = "Rope", IsSqueaky = false },
+            new DogToy { Name = "Squeaky Bone", IsSqueaky = true },
+            new DogToy { Name = "Tennis Ball", IsSqueaky = false },
+        };
 
         [PGList]
         [PGGroup("Lists")]

--- a/sandbox/wpf/UI/Controls/PropertyGridControlExample.xaml.cs
+++ b/sandbox/wpf/UI/Controls/PropertyGridControlExample.xaml.cs
@@ -253,7 +253,8 @@
 
         // Complex-element list - each row is a DogToy with identity, so the selection tester can resolve
         // a selected element (or sub-property) row back to the instance and select it programmatically.
-        [PGList]
+        // ElementDisplayMemberName fills each element row's otherwise-blank value column with the toy's Name.
+        [PGList(ElementDisplayMemberName = nameof(DogToy.Name))]
         [PGGroup("Lists")]
         public List<DogToy> Toys { get; set; } = new List<DogToy>
         {

--- a/sandbox/wpf/UI/Controls/ToggleStripExampleDisplay.xaml
+++ b/sandbox/wpf/UI/Controls/ToggleStripExampleDisplay.xaml
@@ -276,6 +276,39 @@
                         </DockPanel>
                     </GroupBox>
 
+                    <GroupBox Header="SelectionChanged (deselect repro)" Margin="0,0,20,0" Padding="10" ToolTip="SelectionChanged must fire on every standalone deselect">
+                        <DockPanel>
+                            <ajut:ToggleStrip DockPanel.Dock="Top" AllowMultiSelect="True" AllowNoSelection="True"
+                                              SelectionChanged="OnSelectionChangedRepro">
+                                <ajut:ToggleStrip.ItemsSource>
+                                    <x:Array Type="{x:Type sys:String}">
+                                        <sys:String>One</sys:String>
+                                        <sys:String>Two</sys:String>
+                                        <sys:String>Three</sys:String>
+                                        <sys:String>Four</sys:String>
+                                    </x:Array>
+                                </ajut:ToggleStrip.ItemsSource>
+                            </ajut:ToggleStrip>
+                            <ajut:ToggleStrip DockPanel.Dock="Top" Margin="0,5,0,0" AllowNoSelection="True"
+                                              SelectionChanged="OnSelectionChangedRepro">
+                                <ajut:ToggleStrip.ItemsSource>
+                                    <x:Array Type="{x:Type sys:String}">
+                                        <sys:String>One</sys:String>
+                                        <sys:String>Two</sys:String>
+                                        <sys:String>Three</sys:String>
+                                    </x:Array>
+                                </ajut:ToggleStrip.ItemsSource>
+                            </ajut:ToggleStrip>
+                            <TextBlock x:Name="SelectionChangedReproStatus" DockPanel.Dock="Top" Margin="0,5,0,0"
+                                       Text="SelectionChanged fired 0 times"/>
+                            <TextBlock Margin="0,5,0,0" FontStyle="Italic" Opacity="0.8" TextWrapping="WrapWithOverflow" MaxWidth="250">
+                                <TextBlock.Inlines>
+                                    <Run Text="Top (multi-select): select two, click one off. Bottom (single-select + allow-none): select one, click it off to empty. The shared counter must tick on each deselect, not only on select."/>
+                                </TextBlock.Inlines>
+                            </TextBlock>
+                        </DockPanel>
+                    </GroupBox>
+
                     <GroupBox Header="Single Element" Margin="0,0,20,0" Padding="10" ToolTip="Single element is effectively a ToggleButton">
                         <DockPanel>
                             <ajut:ToggleStrip AllowMultiSelect="True" AllowNoSelection="True" DockPanel.Dock="Top">

--- a/sandbox/wpf/UI/Controls/ToggleStripExampleDisplay.xaml.cs
+++ b/sandbox/wpf/UI/Controls/ToggleStripExampleDisplay.xaml.cs
@@ -1,6 +1,7 @@
 ﻿namespace TheAJutShowRoom.UI.Controls
 {
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Windows;
     using System.Windows.Controls;
     using DPUtils = AJut.UX.DPUtils<ToggleStripExampleDisplay>;
@@ -8,6 +9,7 @@
     public partial class ToggleStripExampleDisplay : UserControl
     {
         private int m_addedItemCounter;
+        private int m_selectionChangedReproCount;
         public ToggleStripExampleDisplay()
         {
             this.ZeroToggleElementsSource = new ObservableCollection<string>();
@@ -37,6 +39,13 @@
         private void ClearItemsFromZeroToggle_OnClick (object sender, System.Windows.RoutedEventArgs e)
         {
             this.ZeroToggleElementsSource.Clear();
+        }
+
+        private void OnSelectionChangedRepro (object sender, AJut.UX.Controls.ToggleStrip.ToggleStripSelectionChangedEventArgs e)
+        {
+            ++m_selectionChangedReproCount;
+            string current = string.Join(", ", e.CurrentSelection.OfType<object>());
+            this.SelectionChangedReproStatus.Text = $"SelectionChanged fired {m_selectionChangedReproCount} times - current: [{current}]";
         }
     }
 }

--- a/test/AJut.UX.Tests/PropertyEditTargetTests.cs
+++ b/test/AJut.UX.Tests/PropertyEditTargetTests.cs
@@ -328,6 +328,101 @@ namespace AJut.UX.Tests
         };
     }
 
+    // ===========[ List element header models ]================================
+
+    /// <summary>Element type exercising every member kind ResolveDisplayMember supports.</summary>
+    public class HeaderElement
+    {
+        public static string StaticLabel => "static-label";
+        public static string StaticField = "static-field";
+
+        public string Name { get; set; } = "unnamed";
+        public int Age { get; set; }
+        public string PublicField = "field-value";
+
+        public string DescribeMethod () => $"{this.Name} ({this.Age})";
+    }
+
+    /// <summary>Plain complex-element list whose element rows show the Name header in every state.</summary>
+    public class ListWithHeaderAlwaysModel
+    {
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.Name))]
+        public List<HeaderElement> Entries { get; set; } = new List<HeaderElement>
+        {
+            new HeaderElement { Name = "Tony", Age = 16 },
+            new HeaderElement { Name = "Jill", Age = 24 },
+        };
+    }
+
+    /// <summary>Plain complex-element list whose element rows show the Name header only while collapsed.</summary>
+    public class ListWithHeaderWhenCollapsedModel
+    {
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.Name), ElementDisplayMemberVisibility = eElementHeaderDisplay.WhenCollapsed)]
+        public List<HeaderElement> Entries { get; set; } = new List<HeaderElement>
+        {
+            new HeaderElement { Name = "Tony", Age = 16 },
+            new HeaderElement { Name = "Jill", Age = 24 },
+        };
+    }
+
+    /// <summary>One header list per member kind, to exercise property/field/method/static/missing resolution.</summary>
+    public class ListHeaderMemberKindsModel
+    {
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.Name))]
+        public List<HeaderElement> ByProperty { get; set; } = NewEntries();
+
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.PublicField))]
+        public List<HeaderElement> ByField { get; set; } = NewEntries();
+
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.DescribeMethod))]
+        public List<HeaderElement> ByMethod { get; set; } = NewEntries();
+
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.StaticLabel))]
+        public List<HeaderElement> ByStatic { get; set; } = NewEntries();
+
+        [PGList(ElementDisplayMemberName = nameof(HeaderElement.StaticField))]
+        public List<HeaderElement> ByStaticField { get; set; } = NewEntries();
+
+        [PGList(ElementDisplayMemberName = "NotARealMember")]
+        public List<HeaderElement> ByMissing { get; set; } = NewEntries();
+
+        private static List<HeaderElement> NewEntries () => new List<HeaderElement>
+        {
+            new HeaderElement { Name = "Tony", Age = 16 },
+        };
+    }
+
+    /// <summary>INPC element so the live header refresh (element property change -> refetch) can be exercised.</summary>
+    public class LiveHeaderElement : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private string m_name;
+        public string Name
+        {
+            get => m_name;
+            set
+            {
+                if (m_name != value)
+                {
+                    m_name = value;
+                    this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Name)));
+                }
+            }
+        }
+    }
+
+    /// <summary>Plain complex-element list over INPC elements, so header refresh is driven live.</summary>
+    public class ListWithLiveHeaderModel
+    {
+        [PGList(ElementDisplayMemberName = nameof(LiveHeaderElement.Name))]
+        public List<LiveHeaderElement> Entries { get; set; } = new List<LiveHeaderElement>
+        {
+            new LiveHeaderElement { Name = "Tony" },
+            new LiveHeaderElement { Name = "Jill" },
+        };
+    }
+
     // ===========[ Property filter models ]====================================
 
     /// <summary>Model with several properties to exercise limitToTheseProperties filtering.</summary>
@@ -1396,11 +1491,134 @@ namespace AJut.UX.Tests
             Assert.AreEqual("Hand-built hint", target.EffectiveToolTip);
         }
 
+        // ===[ List element header ]==============================================
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_ResolvesPropertyFieldMethodAndStatic ()
+        {
+            var model = new ListHeaderMemberKindsModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            Assert.AreEqual("Tony", FirstElement(targets, "ByProperty").ListElementHeaderText);
+            Assert.AreEqual("field-value", FirstElement(targets, "ByField").ListElementHeaderText);
+            Assert.AreEqual("Tony (16)", FirstElement(targets, "ByMethod").ListElementHeaderText);
+            Assert.AreEqual("static-label", FirstElement(targets, "ByStatic").ListElementHeaderText);
+            Assert.AreEqual("static-field", FirstElement(targets, "ByStaticField").ListElementHeaderText);
+
+            // A member that does not exist resolves to no header text and stays hidden.
+            var missing = FirstElement(targets, "ByMissing");
+            Assert.IsTrue(string.IsNullOrEmpty(missing.ListElementHeaderText));
+            Assert.IsFalse(missing.IsListElementHeaderVisible);
+        }
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_Always_FillsValueColumnAndIsVisible ()
+        {
+            var model = new ListWithHeaderAlwaysModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            var list = Find(targets, "Entries");
+            var elements = list.Children.OfType<PropertyEditTarget>().ToList();
+            Assert.AreEqual(2, elements.Count);
+
+            // Expandable complex element rows have no inline editor, so the header occupies the value column.
+            Assert.IsTrue(elements[0].IsExpandable);
+            Assert.IsFalse(elements[0].HasInlineEditor);
+            Assert.AreEqual("Tony", elements[0].ListElementHeaderText);
+            Assert.AreEqual("Jill", elements[1].ListElementHeaderText);
+            Assert.IsTrue(elements[0].IsListElementHeaderVisible, "Header should be visible on a collapsed row");
+        }
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_Always_StaysVisibleWhenExpanded ()
+        {
+            var model = new ListWithHeaderAlwaysModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            var elem0 = Find(targets, "Entries").Children.OfType<PropertyEditTarget>().First();
+            elem0.IsExpanded = true;
+            Assert.IsTrue(elem0.IsListElementHeaderVisible, "Always mode keeps the header visible while expanded");
+        }
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_WhenCollapsed_HidesWhileExpanded ()
+        {
+            var model = new ListWithHeaderWhenCollapsedModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            var elem0 = Find(targets, "Entries").Children.OfType<PropertyEditTarget>().First();
+            Assert.IsTrue(elem0.IsListElementHeaderVisible, "Collapsed row should show the header");
+
+            elem0.IsExpanded = true;
+            Assert.IsFalse(elem0.IsListElementHeaderVisible, "Expanded row should hide a when-collapsed header");
+
+            elem0.IsExpanded = false;
+            Assert.IsTrue(elem0.IsListElementHeaderVisible, "Re-collapsing should restore the header");
+        }
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_ReResolvesOnExpandToggle ()
+        {
+            var model = new ListWithHeaderAlwaysModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            var elem0 = Find(targets, "Entries").Children.OfType<PropertyEditTarget>().First();
+            Assert.AreEqual("Tony", elem0.ListElementHeaderText);
+
+            // An edit made while expanded should reflect once the row's expand state changes - no
+            // event subscription is involved, the header re-resolves from the live element.
+            model.Entries[0].Name = "Anthony";
+            elem0.IsExpanded = true;
+            elem0.IsExpanded = false;
+            Assert.AreEqual("Anthony", elem0.ListElementHeaderText);
+        }
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_RefreshesLiveWhenElementMemberChanges ()
+        {
+            var model = new ListWithLiveHeaderModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            var elem0 = Find(targets, "Entries").Children.OfType<PropertyEditTarget>().First();
+            Assert.AreEqual("Tony", elem0.ListElementHeaderText);
+
+            // No expand/collapse - an INPC element raises PropertyChanged, so the header refreshes live.
+            model.Entries[0].Name = "Anthony";
+            Assert.AreEqual("Anthony", elem0.ListElementHeaderText);
+        }
+
+        [TestMethod]
+        public void PET_PGList_ElementHeader_TeardownUnsubscribesLiveRefresh ()
+        {
+            var model = new ListWithLiveHeaderModel();
+            var targets = PropertyEditTarget.GenerateForPropertiesOf(model).ToList();
+            SetupAll(targets);
+
+            var elem0 = Find(targets, "Entries").Children.OfType<PropertyEditTarget>().First();
+            elem0.Teardown();
+
+            // After teardown the element's PropertyChanged is no longer observed - the subscription is gone,
+            // so a later change neither updates the header nor leaves the target pinned to the element.
+            model.Entries[0].Name = "Anthony";
+            Assert.AreEqual("Tony", elem0.ListElementHeaderText, "Header must not update after teardown");
+        }
+
         // ===[ Helpers ]==========================================================
 
         private static PropertyEditTarget Find (List<PropertyEditTarget> targets, string propertyPath)
         {
             return targets.FirstOrDefault(t => t.PropertyPathTarget == propertyPath);
+        }
+
+        private static PropertyEditTarget FirstElement (List<PropertyEditTarget> targets, string listPropertyPath)
+        {
+            return Find(targets, listPropertyPath).Children.OfType<PropertyEditTarget>().First();
         }
 
         private static void SetupAll (List<PropertyEditTarget> targets)


### PR DESCRIPTION
Originally this was just some property grid work - however in so doing, I found some memory leaks. Then because the memory leak rabbit hole took so long, I found another thing I needed to get done with toggle strip selection (allowing better control from the cs). Just getting this set of several changes in a trench coat submitted at this point.

The main elements are:
- Handling property grid selection translation outside of property grid (so push from cs, pull to cs)
- Handling of similar toggle strip cs-behind-the-scenes type of management
- Property grid memory leak fixes