### PR TITLE
Brush buttons

### DIFF
--- a/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
+++ b/libs/AJut.UX.WinUI3/AJut.UX.WinUI3.csproj
@@ -55,6 +55,15 @@
     <Compile Update="Controls\GeometryButton.cs">
       <DependentUpon>GeometryButton.xaml</DependentUpon>
     </Compile>
+    <Compile Update="Controls\_ManagedBrushButton.cs">
+      <DependentUpon>ManagedBrushButtons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\BrushButton.cs">
+      <DependentUpon>ManagedBrushButtons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\AutoBrushButton.cs">
+      <DependentUpon>ManagedBrushButtons.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Controls\FlatTreeListControl.cs">
       <DependentUpon>FlatTreeListControl.xaml</DependentUpon>
     </Compile>

--- a/libs/AJut.UX.WinUI3/ColorMathExtensions.cs
+++ b/libs/AJut.UX.WinUI3/ColorMathExtensions.cs
@@ -1,0 +1,25 @@
+namespace AJut.UX
+{
+    using AJut.UX.Helpers;
+    using Microsoft.UI.Xaml.Media;
+    using Windows.UI;
+
+    /// <summary>
+    /// WinUI3 conveniences over the framework neutral color math in <see cref="AJutColorHelper"/>. These
+    /// just translate a WinUI <see cref="Color"/> in and out of <see cref="ColorArgb"/> so callers do not
+    /// have to think in bytes.
+    /// </summary>
+    public static class ColorMathExtensions
+    {
+        public static ColorArgb ToColorArgb (this Color color) => new ColorArgb(color.A, color.R, color.G, color.B);
+        public static Color ToWindowsColor (this ColorArgb color) => new Color { A = color.A, R = color.R, G = color.G, B = color.B };
+        public static SolidColorBrush ToBrush (this ColorArgb color) => new SolidColorBrush(color.ToWindowsColor());
+
+        public static Color PickReadableForeground (this Color background) => AJutColorHelper.PickReadableForeground(background.ToColorArgb()).ToWindowsColor();
+        public static Color Lighten (this Color color, double amount) => AJutColorHelper.Lighten(color.ToColorArgb(), amount).ToWindowsColor();
+        public static Color Darken (this Color color, double amount) => AJutColorHelper.Darken(color.ToColorArgb(), amount).ToWindowsColor();
+        public static double GetRelativeLuminance (this Color color) => AJutColorHelper.GetRelativeLuminance(color.ToColorArgb());
+        public static double GetContrastRatio (this Color first, Color second) => AJutColorHelper.GetContrastRatio(first.ToColorArgb(), second.ToColorArgb());
+        public static bool IsDark (this Color color) => AJutColorHelper.IsDark(color.ToColorArgb());
+    }
+}

--- a/libs/AJut.UX.WinUI3/Controls/AutoBrushButton.cs
+++ b/libs/AJut.UX.WinUI3/Controls/AutoBrushButton.cs
@@ -1,0 +1,56 @@
+namespace AJut.UX.Controls
+{
+    using AJut.UX;
+    using AJut.UX.Helpers;
+    using Microsoft.UI.Xaml;
+    using Windows.UI;
+    using DPUtils = AJut.UX.DPUtils<AutoBrushButton>;
+
+    /// <summary>
+    /// A button you color with a single accent. Hand it one PropagatedAccentColor and it derives a
+    /// coherent, readable palette - a foreground that contrasts the accent, a visible border, and the
+    /// pointer over / pressed / disabled variants - with no per state brushes and no ResourceDictionary
+    /// override. The derivation lives in <see cref="InteractiveSurfaceColors.BuildFromAccent"/>.
+    /// </summary>
+    public class AutoBrushButton : _ManagedBrushButton
+    {
+        private InteractiveSurfaceColors m_palette;
+
+        public AutoBrushButton ()
+        {
+            this.DefaultStyleKey = typeof(AutoBrushButton);
+            this.RebuildPalette();
+        }
+
+        // ===========[ Dependency Properties ]===================================
+        public static readonly DependencyProperty PropagatedAccentColorProperty = DPUtils.Register(_ => _.PropagatedAccentColor, (d, e) => d.OnPropagatedAccentColorChanged());
+        public Color PropagatedAccentColor { get => (Color)this.GetValue(PropagatedAccentColorProperty); set => this.SetValue(PropagatedAccentColorProperty, value); }
+
+        // ===========[ Public Interface Methods ]===================================
+        protected override SurfaceBrushes GetBrushesForState (eManagedButtonState state)
+        {
+            SurfaceStateColors colors = state switch
+            {
+                eManagedButtonState.PointerOver => m_palette.PointerOver,
+                eManagedButtonState.Pressed => m_palette.Pressed,
+                eManagedButtonState.Disabled => m_palette.Disabled,
+                _ => m_palette.Normal,
+            };
+
+            return new SurfaceBrushes(colors.Background.ToBrush(), colors.Foreground.ToBrush(), colors.Border.ToBrush());
+        }
+
+        // ===========[ Events ]===================================
+        private void OnPropagatedAccentColorChanged ()
+        {
+            this.RebuildPalette();
+            this.RefreshActiveStateBrushes();
+        }
+
+        // ===========[ Helper Methods ]===================================
+        private void RebuildPalette ()
+        {
+            m_palette = InteractiveSurfaceColors.BuildFromAccent(this.PropagatedAccentColor.ToColorArgb());
+        }
+    }
+}

--- a/libs/AJut.UX.WinUI3/Controls/BrushButton.cs
+++ b/libs/AJut.UX.WinUI3/Controls/BrushButton.cs
@@ -1,0 +1,70 @@
+namespace AJut.UX.Controls
+{
+    using Microsoft.UI.Xaml;
+    using Microsoft.UI.Xaml.Media;
+    using DPUtils = AJut.UX.DPUtils<BrushButton>;
+
+    /// <summary>
+    /// A button whose per state brushes are plain dependency properties - set them, bind them, or point
+    /// them at a {ThemeResource}, no per instance ResourceDictionary override required. Every slot defaults
+    /// (in the default style) to the matching standard WinUI button brush, so an untouched BrushButton
+    /// behaves exactly like a normal button - full hover / pressed / disabled feedback - and you override
+    /// only the slots you care about. For "one color, everything derived" use AutoBrushButton instead.
+    /// </summary>
+    public class BrushButton : _ManagedBrushButton
+    {
+        public BrushButton ()
+        {
+            this.DefaultStyleKey = typeof(BrushButton);
+        }
+
+        // ===========[ Dependency Properties ]===================================
+        public static readonly DependencyProperty NormalBackgroundProperty = DPUtils.Register(_ => _.NormalBackground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush NormalBackground { get => (Brush)this.GetValue(NormalBackgroundProperty); set => this.SetValue(NormalBackgroundProperty, value); }
+
+        public static readonly DependencyProperty NormalForegroundProperty = DPUtils.Register(_ => _.NormalForeground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush NormalForeground { get => (Brush)this.GetValue(NormalForegroundProperty); set => this.SetValue(NormalForegroundProperty, value); }
+
+        public static readonly DependencyProperty NormalBorderBrushProperty = DPUtils.Register(_ => _.NormalBorderBrush, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush NormalBorderBrush { get => (Brush)this.GetValue(NormalBorderBrushProperty); set => this.SetValue(NormalBorderBrushProperty, value); }
+
+        public static readonly DependencyProperty PointerOverBackgroundProperty = DPUtils.Register(_ => _.PointerOverBackground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush PointerOverBackground { get => (Brush)this.GetValue(PointerOverBackgroundProperty); set => this.SetValue(PointerOverBackgroundProperty, value); }
+
+        public static readonly DependencyProperty PointerOverForegroundProperty = DPUtils.Register(_ => _.PointerOverForeground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush PointerOverForeground { get => (Brush)this.GetValue(PointerOverForegroundProperty); set => this.SetValue(PointerOverForegroundProperty, value); }
+
+        public static readonly DependencyProperty PointerOverBorderBrushProperty = DPUtils.Register(_ => _.PointerOverBorderBrush, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush PointerOverBorderBrush { get => (Brush)this.GetValue(PointerOverBorderBrushProperty); set => this.SetValue(PointerOverBorderBrushProperty, value); }
+
+        public static readonly DependencyProperty PressedBackgroundProperty = DPUtils.Register(_ => _.PressedBackground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush PressedBackground { get => (Brush)this.GetValue(PressedBackgroundProperty); set => this.SetValue(PressedBackgroundProperty, value); }
+
+        public static readonly DependencyProperty PressedForegroundProperty = DPUtils.Register(_ => _.PressedForeground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush PressedForeground { get => (Brush)this.GetValue(PressedForegroundProperty); set => this.SetValue(PressedForegroundProperty, value); }
+
+        public static readonly DependencyProperty PressedBorderBrushProperty = DPUtils.Register(_ => _.PressedBorderBrush, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush PressedBorderBrush { get => (Brush)this.GetValue(PressedBorderBrushProperty); set => this.SetValue(PressedBorderBrushProperty, value); }
+
+        public static readonly DependencyProperty DisabledBackgroundProperty = DPUtils.Register(_ => _.DisabledBackground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush DisabledBackground { get => (Brush)this.GetValue(DisabledBackgroundProperty); set => this.SetValue(DisabledBackgroundProperty, value); }
+
+        public static readonly DependencyProperty DisabledForegroundProperty = DPUtils.Register(_ => _.DisabledForeground, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush DisabledForeground { get => (Brush)this.GetValue(DisabledForegroundProperty); set => this.SetValue(DisabledForegroundProperty, value); }
+
+        public static readonly DependencyProperty DisabledBorderBrushProperty = DPUtils.Register(_ => _.DisabledBorderBrush, (d, e) => d.RefreshActiveStateBrushes());
+        public Brush DisabledBorderBrush { get => (Brush)this.GetValue(DisabledBorderBrushProperty); set => this.SetValue(DisabledBorderBrushProperty, value); }
+
+        // ===========[ Public Interface Methods ]===================================
+        protected override SurfaceBrushes GetBrushesForState (eManagedButtonState state)
+        {
+            return state switch
+            {
+                eManagedButtonState.PointerOver => new SurfaceBrushes(this.PointerOverBackground, this.PointerOverForeground, this.PointerOverBorderBrush),
+                eManagedButtonState.Pressed => new SurfaceBrushes(this.PressedBackground, this.PressedForeground, this.PressedBorderBrush),
+                eManagedButtonState.Disabled => new SurfaceBrushes(this.DisabledBackground, this.DisabledForeground, this.DisabledBorderBrush),
+                _ => new SurfaceBrushes(this.NormalBackground, this.NormalForeground, this.NormalBorderBrush),
+            };
+        }
+    }
+}

--- a/libs/AJut.UX.WinUI3/Controls/ManagedBrushButtons.xaml
+++ b/libs/AJut.UX.WinUI3/Controls/ManagedBrushButtons.xaml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AJut.UX.Controls">
+
+    <!--
+        BrushButton and AutoBrushButton share one structural template: a Border (PART_Root) hosting a
+        ContentPresenter (PART_ContentPresenter), with a CommonStates group whose states are intentionally
+        empty. ButtonBase drives that group; the control reacts to the state change in code and paints
+        PART_Root.Background / .BorderBrush and PART_ContentPresenter.Foreground from its own brushes. That
+        is why none of those three are TemplateBound here - a TemplateBinding would clobber the code set
+        value (see the WinUI3 theming KB).
+    -->
+    <Style x:Key="AJut_ManagedBrushButtonBaseStyle" TargetType="Button">
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="HorizontalContentAlignment" Value="Center" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="Padding" Value="{StaticResource ButtonPadding}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource ButtonBorderThemeThickness}" />
+        <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}" />
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontWeight" Value="Normal" />
+        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+        <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+        <Setter Property="FocusVisualMargin" Value="-3" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="PART_Root"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{TemplateBinding CornerRadius}">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver" />
+                                <VisualState x:Name="Pressed" />
+                                <VisualState x:Name="Disabled" />
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                          Content="{TemplateBinding Content}"
+                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                          ContentTransitions="{TemplateBinding ContentTransitions}"
+                                          Padding="{TemplateBinding Padding}"
+                                          HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          AutomationProperties.AccessibilityView="Raw" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Each slot defaults to the standard WinUI button brush, so an untouched BrushButton behaves like a
+         normal button (full hover / pressed / disabled feedback). Override only the slots you care about. -->
+    <Style TargetType="local:BrushButton" BasedOn="{StaticResource AJut_ManagedBrushButtonBaseStyle}">
+        <Setter Property="NormalBackground" Value="{ThemeResource ButtonBackground}" />
+        <Setter Property="NormalForeground" Value="{ThemeResource ButtonForeground}" />
+        <Setter Property="NormalBorderBrush" Value="{ThemeResource ButtonBorderBrush}" />
+        <Setter Property="PointerOverBackground" Value="{ThemeResource ButtonBackgroundPointerOver}" />
+        <Setter Property="PointerOverForeground" Value="{ThemeResource ButtonForegroundPointerOver}" />
+        <Setter Property="PointerOverBorderBrush" Value="{ThemeResource ButtonBorderBrushPointerOver}" />
+        <Setter Property="PressedBackground" Value="{ThemeResource ButtonBackgroundPressed}" />
+        <Setter Property="PressedForeground" Value="{ThemeResource ButtonForegroundPressed}" />
+        <Setter Property="PressedBorderBrush" Value="{ThemeResource ButtonBorderBrushPressed}" />
+        <Setter Property="DisabledBackground" Value="{ThemeResource ButtonBackgroundDisabled}" />
+        <Setter Property="DisabledForeground" Value="{ThemeResource ButtonForegroundDisabled}" />
+        <Setter Property="DisabledBorderBrush" Value="{ThemeResource ButtonBorderBrushDisabled}" />
+    </Style>
+
+    <!-- Defaults to the system accent so it shows something coherent before the consumer sets a color. -->
+    <Style TargetType="local:AutoBrushButton" BasedOn="{StaticResource AJut_ManagedBrushButtonBaseStyle}">
+        <Setter Property="PropagatedAccentColor" Value="{ThemeResource SystemAccentColor}" />
+    </Style>
+</ResourceDictionary>

--- a/libs/AJut.UX.WinUI3/Controls/_ManagedBrushButton.cs
+++ b/libs/AJut.UX.WinUI3/Controls/_ManagedBrushButton.cs
@@ -1,0 +1,130 @@
+namespace AJut.UX.Controls
+{
+    using System.Linq;
+    using Microsoft.UI.Xaml;
+    using Microsoft.UI.Xaml.Controls;
+    using Microsoft.UI.Xaml.Media;
+
+    /// <summary>
+    /// Shared plumbing for the brush driven buttons. The standard WinUI Button drives its background,
+    /// foreground, and border brushes through the {ThemeResource ButtonBackground...} keys baked into its
+    /// template's VisualStateManager, which is why recoloring a single button forces that awkward per
+    /// instance ResourceDictionary override (and rules out binding). This base sidesteps it: it stays a
+    /// plain Button - so ButtonBase still owns the Normal/PointerOver/Pressed/Disabled state machine - but
+    /// instead of theme resource VSM setters it listens for the state change and pushes the resolved
+    /// brushes straight onto the template parts. Subclasses only have to answer "which brushes for this
+    /// state".
+    ///
+    /// Not meant to be used directly - use BrushButton or AutoBrushButton.
+    /// </summary>
+    [TemplatePart(Name = nameof(PART_Root), Type = typeof(Border))]
+    [TemplatePart(Name = nameof(PART_ContentPresenter), Type = typeof(ContentPresenter))]
+    [TemplateVisualState(Name = "Normal", GroupName = "CommonStates")]
+    [TemplateVisualState(Name = "PointerOver", GroupName = "CommonStates")]
+    [TemplateVisualState(Name = "Pressed", GroupName = "CommonStates")]
+    [TemplateVisualState(Name = "Disabled", GroupName = "CommonStates")]
+    public abstract class _ManagedBrushButton : Button
+    {
+        // ===========[ Constants ]===================================
+        private const string kCommonStatesGroup = "CommonStates";
+        private const string kStateNormal = "Normal";
+        private const string kStatePointerOver = "PointerOver";
+        private const string kStatePressed = "Pressed";
+        private const string kStateDisabled = "Disabled";
+
+        // ===========[ Instance Fields ]===================================
+        private VisualStateGroup m_commonStates;
+        private eManagedButtonState m_activeState = eManagedButtonState.Normal;
+
+        // ===========[ Setup/Construction/Teardown ]===================================
+        protected _ManagedBrushButton ()
+        {
+        }
+
+        // ===========[ Properties ]===================================
+        protected Border PART_Root { get; private set; }
+        protected ContentPresenter PART_ContentPresenter { get; private set; }
+
+        // ===========[ Public Interface Methods ]===================================
+        protected override void OnApplyTemplate ()
+        {
+            // ButtonBase wires up the CommonStates machine in its own OnApplyTemplate, so let it run first.
+            base.OnApplyTemplate();
+
+            if (m_commonStates != null)
+            {
+                m_commonStates.CurrentStateChanged -= this.OnCommonStateChanged;
+            }
+
+            this.PART_Root = this.GetTemplateChild(nameof(PART_Root)) as Border;
+            this.PART_ContentPresenter = this.GetTemplateChild(nameof(PART_ContentPresenter)) as ContentPresenter;
+
+            m_commonStates = this.PART_Root == null
+                ? null
+                : VisualStateManager.GetVisualStateGroups(this.PART_Root).FirstOrDefault(group => group.Name == kCommonStatesGroup);
+
+            if (m_commonStates != null)
+            {
+                m_commonStates.CurrentStateChanged -= this.OnCommonStateChanged;
+                m_commonStates.CurrentStateChanged += this.OnCommonStateChanged;
+            }
+
+            // base.OnApplyTemplate already drove the opening GoToState, so seed from wherever it landed.
+            m_activeState = _ParseState(m_commonStates?.CurrentState?.Name)
+                ?? (this.IsEnabled ? eManagedButtonState.Normal : eManagedButtonState.Disabled);
+            this.RefreshActiveStateBrushes();
+        }
+
+        /// <summary>Re-resolves and re-applies the brushes for the current visual state. Call when a brush source changes.</summary>
+        protected void RefreshActiveStateBrushes ()
+        {
+            if (this.PART_Root == null)
+            {
+                return;
+            }
+
+            SurfaceBrushes brushes = this.GetBrushesForState(m_activeState);
+            this.PART_Root.Background = brushes.Background;
+            this.PART_Root.BorderBrush = brushes.Border;
+            if (this.PART_ContentPresenter != null)
+            {
+                this.PART_ContentPresenter.Foreground = brushes.Foreground;
+            }
+        }
+
+        /// <summary>Subclasses answer which brushes to paint for a given interaction state. Any may be null (no paint).</summary>
+        protected abstract SurfaceBrushes GetBrushesForState (eManagedButtonState state);
+
+        // ===========[ Events ]===================================
+        private void OnCommonStateChanged (object sender, VisualStateChangedEventArgs e)
+        {
+            m_activeState = _ParseState(e.NewState?.Name) ?? eManagedButtonState.Normal;
+            this.RefreshActiveStateBrushes();
+        }
+
+        // ===========[ Helper Methods ]===================================
+        private static eManagedButtonState? _ParseState (string stateName)
+        {
+            return stateName switch
+            {
+                kStateNormal => eManagedButtonState.Normal,
+                kStatePointerOver => eManagedButtonState.PointerOver,
+                kStatePressed => eManagedButtonState.Pressed,
+                kStateDisabled => eManagedButtonState.Disabled,
+                _ => null,
+            };
+        }
+
+        // ===========[ Subclasses/structs ]===================================
+        /// <summary>The resolved brushes to paint for one interaction state. Any may be null (no paint).</summary>
+        protected readonly record struct SurfaceBrushes (Brush Background, Brush Foreground, Brush Border);
+    }
+
+    public enum eManagedButtonState
+    {
+        Normal,
+        PointerOver,
+        Pressed,
+        Disabled,
+    }
+}

--- a/libs/AJut.UX.WinUI3/Themes/Generic.xaml
+++ b/libs/AJut.UX.WinUI3/Themes/Generic.xaml
@@ -22,6 +22,7 @@
         <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/EnumComboBox.xaml"/>
         <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/EnumToggleStrip.xaml"/>
         <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/GeometryButton.xaml"/>
+        <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/ManagedBrushButtons.xaml"/>
         <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/TitleBarCaptionButton.xaml"/>
         <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/ThemedWindowRootControl.xaml"/>
         <ResourceDictionary Source="ms-appx:///AJut.UX.WinUI3/Controls/FlatTreeListControl.xaml"/>

--- a/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
+++ b/libs/AJut.UX.Wpf/AJut.UX.Wpf.csproj
@@ -33,6 +33,15 @@
     <Compile Update="Controls\ColorValueEditControl.cs">
       <DependentUpon>ColorValueEditControl.xaml</DependentUpon>
     </Compile>
+    <Compile Update="Controls\_ManagedBrushButton.cs">
+      <DependentUpon>ManagedBrushButtons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\BrushButton.cs">
+      <DependentUpon>ManagedBrushButtons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Controls\AutoBrushButton.cs">
+      <DependentUpon>ManagedBrushButtons.xaml</DependentUpon>
+    </Compile>
     <Compile Update="Controls\DockingElements\DefaultDockTearoffWindow.cs">
       <DependentUpon>DefaultDockTearoffWindow.xaml</DependentUpon>
     </Compile>

--- a/libs/AJut.UX.Wpf/ColorMathExtensions.cs
+++ b/libs/AJut.UX.Wpf/ColorMathExtensions.cs
@@ -1,0 +1,30 @@
+namespace AJut.UX
+{
+    using AJut.UX.Helpers;
+    using System.Windows.Media;
+
+    /// <summary>
+    /// WPF conveniences over the framework neutral color math in <see cref="AJutColorHelper"/>. These just
+    /// translate a WPF <see cref="Color"/> in and out of <see cref="ColorArgb"/> so callers do not have to
+    /// think in bytes.
+    /// </summary>
+    public static class ColorMathExtensions
+    {
+        public static ColorArgb ToColorArgb (this Color color) => new ColorArgb(color.A, color.R, color.G, color.B);
+        public static Color ToMediaColor (this ColorArgb color) => Color.FromArgb(color.A, color.R, color.G, color.B);
+
+        public static SolidColorBrush ToBrush (this ColorArgb color)
+        {
+            var brush = new SolidColorBrush(color.ToMediaColor());
+            brush.Freeze();
+            return brush;
+        }
+
+        public static Color PickReadableForeground (this Color background) => AJutColorHelper.PickReadableForeground(background.ToColorArgb()).ToMediaColor();
+        public static Color Lighten (this Color color, double amount) => AJutColorHelper.Lighten(color.ToColorArgb(), amount).ToMediaColor();
+        public static Color Darken (this Color color, double amount) => AJutColorHelper.Darken(color.ToColorArgb(), amount).ToMediaColor();
+        public static double GetRelativeLuminance (this Color color) => AJutColorHelper.GetRelativeLuminance(color.ToColorArgb());
+        public static double GetContrastRatio (this Color first, Color second) => AJutColorHelper.GetContrastRatio(first.ToColorArgb(), second.ToColorArgb());
+        public static bool IsDark (this Color color) => AJutColorHelper.IsDark(color.ToColorArgb());
+    }
+}

--- a/libs/AJut.UX.Wpf/Controls/AutoBrushButton.cs
+++ b/libs/AJut.UX.Wpf/Controls/AutoBrushButton.cs
@@ -2,23 +2,27 @@ namespace AJut.UX.Controls
 {
     using AJut.UX;
     using AJut.UX.Helpers;
-    using Microsoft.UI.Xaml;
-    using Windows.UI;
+    using System.Windows;
+    using System.Windows.Media;
     using DPUtils = AJut.UX.DPUtils<AutoBrushButton>;
 
     /// <summary>
     /// A button you color with a single accent. Hand it one PropagatedAccentColor and it derives a
     /// coherent, readable palette - a foreground that contrasts the accent, a visible border, and the
-    /// pointer over / pressed / disabled variants - with no per state brushes and no ResourceDictionary
+    /// mouse-over / pressed / disabled variants - with no per state brushes and no ResourceDictionary
     /// override. The derivation lives in <see cref="InteractiveSurfaceColors.BuildFromAccent"/>.
     /// </summary>
     public class AutoBrushButton : _ManagedBrushButton
     {
         private InteractiveSurfaceColors m_palette;
 
+        static AutoBrushButton ()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(AutoBrushButton), new FrameworkPropertyMetadata(typeof(AutoBrushButton)));
+        }
+
         public AutoBrushButton ()
         {
-            this.DefaultStyleKey = typeof(AutoBrushButton);
             this.RebuildPalette();
         }
 

--- a/libs/AJut.UX.Wpf/Controls/BrushButton.cs
+++ b/libs/AJut.UX.Wpf/Controls/BrushButton.cs
@@ -1,21 +1,21 @@
 namespace AJut.UX.Controls
 {
-    using Microsoft.UI.Xaml;
-    using Microsoft.UI.Xaml.Media;
+    using System.Windows;
+    using System.Windows.Media;
     using DPUtils = AJut.UX.DPUtils<BrushButton>;
 
     /// <summary>
     /// A button whose per state brushes are plain dependency properties - set them, bind them, or point
-    /// them at a {ThemeResource}, no per instance ResourceDictionary override required. Every slot defaults
-    /// (in the default style) to the matching standard WinUI button brush, so an untouched BrushButton
-    /// behaves exactly like a normal button - full hover / pressed / disabled feedback - and you override
-    /// only the slots you care about. For "one color, everything derived" use AutoBrushButton instead.
+    /// them at a {DynamicResource}, no per instance ResourceDictionary override required. Every slot defaults
+    /// (in the default style) to the matching AJut button brush, so an untouched BrushButton behaves like a
+    /// normal button - full mouse-over / pressed / disabled feedback - and you override only the slots you
+    /// care about. For "one color, everything derived" use AutoBrushButton instead.
     /// </summary>
     public class BrushButton : _ManagedBrushButton
     {
-        public BrushButton ()
+        static BrushButton ()
         {
-            this.DefaultStyleKey = typeof(BrushButton);
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(BrushButton), new FrameworkPropertyMetadata(typeof(BrushButton)));
         }
 
         // ===========[ Dependency Properties ]===================================

--- a/libs/AJut.UX.Wpf/Controls/ManagedBrushButtons.xaml
+++ b/libs/AJut.UX.Wpf/Controls/ManagedBrushButtons.xaml
@@ -1,0 +1,65 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="clr-namespace:AJut.UX.Controls">
+
+    <!--
+        BrushButton and AutoBrushButton share one structural template: a Border (PART_Root) hosting a
+        ContentPresenter. The control computes the brushes for the current state in code and publishes them
+        on its read-only Effective* DPs; the template binds the visual Background / BorderBrush / content
+        Foreground to those, so the actual visual assignment stays in XAML. The bindings use a TemplatedParent
+        Binding (not TemplateBinding) so the template can target ButtonBase while still reaching the Effective*
+        and CornerRadius DPs that live on _ManagedBrushButton.
+    -->
+    <Style x:Key="AJut_ManagedBrushButtonBaseStyle" TargetType="{x:Type ButtonBase}">
+        <Setter Property="HorizontalAlignment" Value="Left"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="HorizontalContentAlignment" Value="Center"/>
+        <Setter Property="VerticalContentAlignment" Value="Center"/>
+        <Setter Property="Padding" Value="8,4"/>
+        <Setter Property="BorderThickness" Value="1"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ButtonBase}">
+                    <Border x:Name="PART_Root"
+                            Background="{Binding EffectiveBackground, RelativeSource={RelativeSource TemplatedParent}}"
+                            BorderBrush="{Binding EffectiveBorderBrush, RelativeSource={RelativeSource TemplatedParent}}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            CornerRadius="{Binding CornerRadius, RelativeSource={RelativeSource TemplatedParent}}"
+                            SnapsToDevicePixels="True">
+                        <ContentPresenter x:Name="PART_ContentPresenter"
+                                          Margin="{TemplateBinding Padding}"
+                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                          TextElement.Foreground="{Binding EffectiveForeground, RelativeSource={RelativeSource TemplatedParent}}"
+                                          RecognizesAccessKey="True"
+                                          SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}"/>
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <!-- Sane light-theme literals only - NO theme brushes belong in the default style. The AJut-themed
+         overrides ({DynamicResource AJut_Brush_*}) live in Resources/ThemedControlStylesBase.xaml and layer
+         on top of these when a consumer loads the AJut theme. -->
+    <Style TargetType="{x:Type local:BrushButton}" BasedOn="{StaticResource AJut_ManagedBrushButtonBaseStyle}">
+        <Setter Property="NormalBackground" Value="#E6E6E6"/>
+        <Setter Property="NormalForeground" Value="#1A1A1A"/>
+        <Setter Property="NormalBorderBrush" Value="#8A8A8A"/>
+        <Setter Property="PointerOverBackground" Value="#F0F0F0"/>
+        <Setter Property="PointerOverForeground" Value="#000000"/>
+        <Setter Property="PointerOverBorderBrush" Value="#555555"/>
+        <Setter Property="PressedBackground" Value="#CFCFCF"/>
+        <Setter Property="PressedForeground" Value="#000000"/>
+        <Setter Property="PressedBorderBrush" Value="#333333"/>
+        <Setter Property="DisabledBackground" Value="#E6E6E6"/>
+        <Setter Property="DisabledForeground" Value="#9A9A9A"/>
+        <Setter Property="DisabledBorderBrush" Value="#C8C8C8"/>
+    </Style>
+
+    <!-- Light-theme default accent; the themed override swaps this for the AJut palette accent. -->
+    <Style TargetType="{x:Type local:AutoBrushButton}" BasedOn="{StaticResource AJut_ManagedBrushButtonBaseStyle}">
+        <Setter Property="PropagatedAccentColor" Value="#0D83D8"/>
+    </Style>
+</ResourceDictionary>

--- a/libs/AJut.UX.Wpf/Controls/_ManagedBrushButton.cs
+++ b/libs/AJut.UX.Wpf/Controls/_ManagedBrushButton.cs
@@ -1,0 +1,111 @@
+namespace AJut.UX.Controls
+{
+    using System.Windows;
+    using System.Windows.Controls;
+    using System.Windows.Media;
+    using DPUtils = AJut.UX.DPUtils<_ManagedBrushButton>;
+
+    /// <summary>
+    /// Shared plumbing for the brush driven buttons. The standard button drives its background, foreground,
+    /// and border through theme-keyed brushes baked into its template, which is why recoloring one button
+    /// forces a per instance ResourceDictionary override (and rules out binding). This base sidesteps it: it
+    /// stays a plain Button - so ButtonBase still owns the mouse-over / pressed / disabled tracking - but it
+    /// computes the brushes for the current state in code and publishes them on the read-only Effective*
+    /// dependency properties. The template binds the visual Border / content to those, so the actual visual
+    /// assignment stays in XAML; the code only does brush calculation and setting. Subclasses just answer
+    /// "which brushes for this state".
+    ///
+    /// Not meant to be used directly - use BrushButton or AutoBrushButton.
+    /// </summary>
+    public abstract class _ManagedBrushButton : Button
+    {
+        // ===========[ Setup/Construction/Teardown ]===================================
+        protected _ManagedBrushButton ()
+        {
+        }
+
+        // ===========[ Dependency Properties ]===================================
+        public static readonly DependencyProperty CornerRadiusProperty = DPUtils.Register(_ => _.CornerRadius, new CornerRadius(3));
+        public CornerRadius CornerRadius
+        {
+            get => (CornerRadius)this.GetValue(CornerRadiusProperty);
+            set => this.SetValue(CornerRadiusProperty, value);
+        }
+
+        private static readonly DependencyPropertyKey EffectiveBackgroundPropertyKey = DPUtils.RegisterReadOnly(_ => _.EffectiveBackground);
+        public static readonly DependencyProperty EffectiveBackgroundProperty = EffectiveBackgroundPropertyKey.DependencyProperty;
+        public Brush EffectiveBackground
+        {
+            get => (Brush)this.GetValue(EffectiveBackgroundProperty);
+            private set => this.SetValue(EffectiveBackgroundPropertyKey, value);
+        }
+
+        private static readonly DependencyPropertyKey EffectiveForegroundPropertyKey = DPUtils.RegisterReadOnly(_ => _.EffectiveForeground);
+        public static readonly DependencyProperty EffectiveForegroundProperty = EffectiveForegroundPropertyKey.DependencyProperty;
+        public Brush EffectiveForeground
+        {
+            get => (Brush)this.GetValue(EffectiveForegroundProperty);
+            private set => this.SetValue(EffectiveForegroundPropertyKey, value);
+        }
+
+        private static readonly DependencyPropertyKey EffectiveBorderBrushPropertyKey = DPUtils.RegisterReadOnly(_ => _.EffectiveBorderBrush);
+        public static readonly DependencyProperty EffectiveBorderBrushProperty = EffectiveBorderBrushPropertyKey.DependencyProperty;
+        public Brush EffectiveBorderBrush
+        {
+            get => (Brush)this.GetValue(EffectiveBorderBrushProperty);
+            private set => this.SetValue(EffectiveBorderBrushPropertyKey, value);
+        }
+
+        // ===========[ Public Interface Methods ]===================================
+        public override void OnApplyTemplate ()
+        {
+            base.OnApplyTemplate();
+            this.RefreshActiveStateBrushes();
+        }
+
+        /// <summary>Recomputes the effective brushes for the current interaction state. Call when a brush source changes.</summary>
+        protected void RefreshActiveStateBrushes ()
+        {
+            SurfaceBrushes brushes = this.GetBrushesForState(this.GetActiveState());
+            this.EffectiveBackground = brushes.Background;
+            this.EffectiveForeground = brushes.Foreground;
+            this.EffectiveBorderBrush = brushes.Border;
+        }
+
+        /// <summary>Subclasses answer which brushes to paint for a given interaction state. Any may be null (no paint).</summary>
+        protected abstract SurfaceBrushes GetBrushesForState (eManagedButtonState state);
+
+        // ===========[ Events ]===================================
+        protected override void OnPropertyChanged (DependencyPropertyChangedEventArgs e)
+        {
+            base.OnPropertyChanged(e);
+            if ((e.Property == IsMouseOverProperty)
+                || (e.Property == IsPressedProperty)
+                || (e.Property == IsEnabledProperty))
+            {
+                this.RefreshActiveStateBrushes();
+            }
+        }
+
+        // ===========[ Helper Methods ]===================================
+        private eManagedButtonState GetActiveState ()
+        {
+            if (!this.IsEnabled) { return eManagedButtonState.Disabled; }
+            if (this.IsPressed) { return eManagedButtonState.Pressed; }
+            if (this.IsMouseOver) { return eManagedButtonState.PointerOver; }
+            return eManagedButtonState.Normal;
+        }
+
+        // ===========[ Subclasses/structs ]===================================
+        /// <summary>The resolved brushes to paint for one interaction state. Any may be null (no paint).</summary>
+        protected readonly record struct SurfaceBrushes (Brush Background, Brush Foreground, Brush Border);
+    }
+
+    public enum eManagedButtonState
+    {
+        Normal,
+        PointerOver,
+        Pressed,
+        Disabled,
+    }
+}

--- a/libs/AJut.UX.Wpf/Resources/ThemedControlStylesBase.xaml
+++ b/libs/AJut.UX.Wpf/Resources/ThemedControlStylesBase.xaml
@@ -355,6 +355,25 @@
         <Setter Property="SwitchPadding" Value="-2"/>
     </Style>
 
+    <Style TargetType="{x:Type ajut_ctrls:BrushButton}">
+        <Setter Property="NormalBackground" Value="{DynamicResource AJut_Brush_ControlBackground}"/>
+        <Setter Property="NormalForeground" Value="{DynamicResource AJut_Brush_NormalText}"/>
+        <Setter Property="NormalBorderBrush" Value="{DynamicResource AJut_Brush_BorderCommon}"/>
+        <Setter Property="PointerOverBackground" Value="{DynamicResource AJut_Brush_ControlBackgroundHover}"/>
+        <Setter Property="PointerOverForeground" Value="{DynamicResource AJut_Brush_HighlightText}"/>
+        <Setter Property="PointerOverBorderBrush" Value="{DynamicResource AJut_Brush_BorderCommonHover}"/>
+        <Setter Property="PressedBackground" Value="{DynamicResource AJut_Brush_ButtonBackgroundPressed}"/>
+        <Setter Property="PressedForeground" Value="{DynamicResource AJut_Brush_HighlightText}"/>
+        <Setter Property="PressedBorderBrush" Value="{DynamicResource AJut_Brush_BorderCommonPress}"/>
+        <Setter Property="DisabledBackground" Value="{DynamicResource AJut_Brush_ControlBackground}"/>
+        <Setter Property="DisabledForeground" Value="{DynamicResource AJut_Brush_InteractiveTextUnfocused}"/>
+        <Setter Property="DisabledBorderBrush" Value="{DynamicResource AJut_Brush_BorderCommon}"/>
+    </Style>
+
+    <Style TargetType="{x:Type ajut_ctrls:AutoBrushButton}">
+        <Setter Property="PropagatedAccentColor" Value="{DynamicResource AJut_Color_PrimaryHighlight}"/>
+    </Style>
+
     <Style TargetType="{x:Type TextBlock}" x:Key="AJut_SymbolText">
         <Setter Property="FontFamily" Value="{DynamicResource AJut_Font_SymbolGlyphText}"/>
         <Setter Property="FontSize" Value="20"/>

--- a/libs/AJut.UX.Wpf/Themes/Generic.xaml
+++ b/libs/AJut.UX.Wpf/Themes/Generic.xaml
@@ -17,11 +17,12 @@
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/EnumComboBox.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/EnumToggleStrip.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/FlatTreeListControl.xaml"/>
+        <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/ManagedBrushButtons.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/MessageBoxPopover.xaml"/>
+        <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/NullableEditor.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/NumericEditor.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/PathSelectionControl.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/PopupMenuButton.xaml"/>
-        <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/NullableEditor.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/PropertyGridListEditor.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/PropertyGrid.xaml"/>
         <ResourceDictionary Source="/AJut.UX.WPF;component/Controls/StackNavDisplayElements/StackNavActiveContentPresenter.xaml"/>

--- a/libs/AJut.UX/Helpers/AJutColorHelper.ColorMath.cs
+++ b/libs/AJut.UX/Helpers/AJutColorHelper.ColorMath.cs
@@ -1,0 +1,186 @@
+namespace AJut.UX.Helpers
+{
+    using System;
+
+    // Byte based color math, kept framework agnostic on purpose: WPF and WinUI3 each ship their own
+    // Color type, so the real work happens here on A/R/G/B bytes and the per framework layers only
+    // convert in and out. The parsing half of this helper lives in AJutColorHelper.cs.
+    public static partial class AJutColorHelper
+    {
+        // 0.179 is the WCAG luminance crossover where white and black give equal contrast. Anchoring the
+        // readable foregrounds at pure white / pure black keeps the worst case (a background sitting right
+        // on the crossover) at a ~4.58 contrast ratio, so the pick always clears WCAG AA.
+        private const double kReadableForegroundLuminanceCrossover = 0.179;
+        private static readonly ColorArgb kReadableLight = new ColorArgb(255, 0xFF, 0xFF, 0xFF);
+        private static readonly ColorArgb kReadableDark = new ColorArgb(255, 0x00, 0x00, 0x00);
+
+        // ===========[ HSL Conversion ]===================================
+
+        /// <summary>Converts an sRGB color to HSL. Alpha is ignored.</summary>
+        public static HslColor RgbToHsl (ColorArgb color)
+        {
+            double r = color.R / 255.0;
+            double g = color.G / 255.0;
+            double b = color.B / 255.0;
+
+            double max = Math.Max(r, Math.Max(g, b));
+            double min = Math.Min(r, Math.Min(g, b));
+            double lightness = (max + min) / 2.0;
+
+            double delta = max - min;
+            if (delta == 0.0)
+            {
+                return new HslColor(0.0, 0.0, lightness);
+            }
+
+            double saturation = lightness > 0.5
+                ? delta / (2.0 - max - min)
+                : delta / (max + min);
+
+            double hue;
+            if (max == r)
+            {
+                hue = ((g - b) / delta) + (g < b ? 6.0 : 0.0);
+            }
+            else if (max == g)
+            {
+                hue = ((b - r) / delta) + 2.0;
+            }
+            else
+            {
+                hue = ((r - g) / delta) + 4.0;
+            }
+
+            hue *= 60.0;
+            return new HslColor(hue, saturation, lightness);
+        }
+
+        /// <summary>Converts HSL back to sRGB, stamping on the given alpha.</summary>
+        public static ColorArgb HslToRgb (HslColor hsl, byte alpha = 255)
+        {
+            double lightness = Math.Clamp(hsl.Lightness, 0.0, 1.0);
+            double saturation = Math.Clamp(hsl.Saturation, 0.0, 1.0);
+
+            if (saturation == 0.0)
+            {
+                byte gray = _ToByte(lightness);
+                return new ColorArgb(alpha, gray, gray, gray);
+            }
+
+            double q = lightness < 0.5
+                ? lightness * (1.0 + saturation)
+                : lightness + saturation - (lightness * saturation);
+            double p = (2.0 * lightness) - q;
+            double h = hsl.Hue / 360.0;
+
+            byte r = _ToByte(_HueToChannel(p, q, h + (1.0 / 3.0)));
+            byte g = _ToByte(_HueToChannel(p, q, h));
+            byte b = _ToByte(_HueToChannel(p, q, h - (1.0 / 3.0)));
+            return new ColorArgb(alpha, r, g, b);
+
+            static double _HueToChannel (double p, double q, double t)
+            {
+                if (t < 0.0) { t += 1.0; }
+                if (t > 1.0) { t -= 1.0; }
+                if (t < (1.0 / 6.0)) { return p + ((q - p) * 6.0 * t); }
+                if (t < (1.0 / 2.0)) { return q; }
+                if (t < (2.0 / 3.0)) { return p + ((q - p) * ((2.0 / 3.0) - t) * 6.0); }
+                return p;
+            }
+        }
+
+        // ===========[ Luminance / Contrast ]===================================
+
+        /// <summary>WCAG relative luminance in [0, 1] (sRGB linearized). Alpha is ignored.</summary>
+        public static double GetRelativeLuminance (ColorArgb color)
+        {
+            return (0.2126 * _Linearize(color.R))
+                 + (0.7152 * _Linearize(color.G))
+                 + (0.0722 * _Linearize(color.B));
+
+            static double _Linearize (byte channel)
+            {
+                double s = channel / 255.0;
+                return s <= 0.03928 ? s / 12.92 : Math.Pow((s + 0.055) / 1.055, 2.4);
+            }
+        }
+
+        /// <summary>WCAG contrast ratio between two colors, in [1, 21]. Alpha is ignored.</summary>
+        public static double GetContrastRatio (ColorArgb first, ColorArgb second)
+        {
+            double l1 = GetRelativeLuminance(first);
+            double l2 = GetRelativeLuminance(second);
+            double lighter = Math.Max(l1, l2);
+            double darker = Math.Min(l1, l2);
+            return (lighter + 0.05) / (darker + 0.05);
+        }
+
+        /// <summary>True when a color is dark enough that a light foreground reads better than a dark one.</summary>
+        public static bool IsDark (ColorArgb color) => GetRelativeLuminance(color) < kReadableForegroundLuminanceCrossover;
+
+        /// <summary>
+        /// Picks a foreground (near white or near black) that reads cleanly on the given background -
+        /// whichever side of the WCAG crossover gives the higher contrast.
+        /// </summary>
+        public static ColorArgb PickReadableForeground (ColorArgb background) => IsDark(background) ? kReadableLight : kReadableDark;
+
+        /// <summary>
+        /// Like <see cref="PickReadableForeground(ColorArgb)"/>, but holds onto a preferred polarity so a
+        /// background that only drifts slightly across the light/dark crossover does not flip the foreground.
+        /// Pass the polarity decided from a base color (e.g. <see cref="IsDark"/> of an accent); the pick only
+        /// flips away from it once the background passes the crossover by more than <paramref name="hysteresis"/>.
+        /// </summary>
+        public static ColorArgb PickReadableForeground (ColorArgb background, bool preferLight, double hysteresis)
+        {
+            double threshold = preferLight
+                ? kReadableForegroundLuminanceCrossover + hysteresis
+                : kReadableForegroundLuminanceCrossover - hysteresis;
+            return GetRelativeLuminance(background) < threshold ? kReadableLight : kReadableDark;
+        }
+
+        // ===========[ Adjustments ]===================================
+
+        /// <summary>Adds <paramref name="delta"/> to the HSL lightness (delta in [-1, 1]), preserving alpha.</summary>
+        public static ColorArgb AdjustLightness (ColorArgb color, double delta)
+        {
+            HslColor hsl = RgbToHsl(color);
+            return HslToRgb(hsl with { Lightness = Math.Clamp(hsl.Lightness + delta, 0.0, 1.0) }, color.A);
+        }
+
+        public static ColorArgb Lighten (ColorArgb color, double amount) => AdjustLightness(color, amount);
+        public static ColorArgb Darken (ColorArgb color, double amount) => AdjustLightness(color, -amount);
+
+        /// <summary>Multiplies HSL saturation by <paramref name="factor"/> (clamped to [0, 1]), preserving alpha.</summary>
+        public static ColorArgb ScaleSaturation (ColorArgb color, double factor)
+        {
+            HslColor hsl = RgbToHsl(color);
+            return HslToRgb(hsl with { Saturation = Math.Clamp(hsl.Saturation * factor, 0.0, 1.0) }, color.A);
+        }
+
+        /// <summary>Linear blend in sRGB (and alpha): t=0 returns <paramref name="from"/>, t=1 returns <paramref name="to"/>.</summary>
+        public static ColorArgb Blend (ColorArgb from, ColorArgb to, double t)
+        {
+            t = Math.Clamp(t, 0.0, 1.0);
+            return new ColorArgb(
+                _Lerp(from.A, to.A, t),
+                _Lerp(from.R, to.R, t),
+                _Lerp(from.G, to.G, t),
+                _Lerp(from.B, to.B, t)
+            );
+
+            static byte _Lerp (byte a, byte b, double t) => (byte)Math.Round(a + ((b - a) * t));
+        }
+
+        private static byte _ToByte (double normalized) => (byte)Math.Clamp((int)Math.Round(normalized * 255.0), 0, 255);
+    }
+
+    /// <summary>An A/R/G/B color as bytes - the framework neutral currency for AJut color math.</summary>
+    public readonly record struct ColorArgb (byte A, byte R, byte G, byte B)
+    {
+        public static ColorArgb FromRgb (byte r, byte g, byte b) => new ColorArgb(255, r, g, b);
+        public ColorArgb WithAlpha (byte alpha) => this with { A = alpha };
+    }
+
+    /// <summary>Hue [0, 360), Saturation [0, 1], Lightness [0, 1].</summary>
+    public readonly record struct HslColor (double Hue, double Saturation, double Lightness);
+}

--- a/libs/AJut.UX/Helpers/AJutColorHelper.cs
+++ b/libs/AJut.UX/Helpers/AJutColorHelper.cs
@@ -6,7 +6,7 @@ namespace AJut.UX.Helpers
     using System.Globalization;
     using System.Net;
 
-    public static class AJutColorHelper
+    public static partial class AJutColorHelper
     {
         /// <summary>Supports #RGB (converts to #RRGGBB), #RRGGBB, and #AARRGGBB. Defaults to ARGB byte order.</summary>
         public static bool TryGetColorFromHex(string hex, out byte[] argb)

--- a/libs/AJut.UX/Helpers/InteractiveSurfaceColors.cs
+++ b/libs/AJut.UX/Helpers/InteractiveSurfaceColors.cs
@@ -1,0 +1,69 @@
+namespace AJut.UX.Helpers
+{
+    /// <summary>The three brushable colors for one interaction state of a surface (button, chip, etc).</summary>
+    public readonly record struct SurfaceStateColors (ColorArgb Background, ColorArgb Foreground, ColorArgb Border);
+
+    /// <summary>
+    /// A full set of interaction state colors (normal / pointer over / pressed / disabled) derived from a
+    /// single accent color. Hand over one color and get a coherent, readable palette back: the background
+    /// brightens on hover and dims on press, the foreground holds one readable polarity across those states
+    /// (no white/black flip on small shifts), and the border sits a step off each state's background.
+    /// </summary>
+    public readonly record struct InteractiveSurfaceColors (
+        SurfaceStateColors Normal,
+        SurfaceStateColors PointerOver,
+        SurfaceStateColors Pressed,
+        SurfaceStateColors Disabled
+    )
+    {
+        // ------ How far each state shifts off the accent. Tuned by eye; these are the knobs to turn.
+        private const double kPointerOverLightnessShift = 0.06; // hover brightens
+        private const double kPressedLightnessShift = 0.10;     // pressed dims
+        private const double kBorderLightnessShift = 0.18;
+        private const double kPressedSaturationScale = 0.92;
+        private const double kDisabledSaturationScale = 0.25;
+        // Hold the accent's foreground polarity across hover / pressed so a small background shift across the
+        // light/dark crossover does not flip the text color. Sized to cover the lightness shifts above.
+        private const double kForegroundHysteresis = 0.12;
+        private const byte kDisabledBackgroundAlpha = 0x40;
+        private const byte kDisabledForegroundAlpha = 0x80;
+        private const byte kDisabledBorderAlpha = 0x40;
+
+        /// <summary>Derives a coherent interaction palette from a single accent (background) color.</summary>
+        public static InteractiveSurfaceColors BuildFromAccent (ColorArgb accent)
+        {
+            // Polarity is decided once from the accent and then held (with hysteresis) across the states, so
+            // the background can brighten / dim on interaction without the foreground flipping black<->white.
+            bool preferLight = AJutColorHelper.IsDark(accent);
+
+            var normal = _BuildState(accent, preferLight);
+            var pointerOver = _BuildState(AJutColorHelper.Lighten(accent, kPointerOverLightnessShift), preferLight);
+
+            ColorArgb pressedBackground = AJutColorHelper.ScaleSaturation(
+                AJutColorHelper.Darken(accent, kPressedLightnessShift),
+                kPressedSaturationScale
+            );
+            var pressed = _BuildState(pressedBackground, preferLight);
+
+            ColorArgb disabledBackground = AJutColorHelper.ScaleSaturation(accent, kDisabledSaturationScale).WithAlpha(kDisabledBackgroundAlpha);
+            var disabled = new SurfaceStateColors(
+                disabledBackground,
+                normal.Foreground.WithAlpha(kDisabledForegroundAlpha),
+                AJutColorHelper.ScaleSaturation(normal.Border, kDisabledSaturationScale).WithAlpha(kDisabledBorderAlpha)
+            );
+
+            return new InteractiveSurfaceColors(normal, pointerOver, pressed, disabled);
+
+            // Foreground from this state's background (holding polarity); border stepped off it for a visible edge.
+            static SurfaceStateColors _BuildState (ColorArgb background, bool preferLight)
+            {
+                double borderDelta = (AJutColorHelper.IsDark(background) ? 1.0 : -1.0) * kBorderLightnessShift;
+                return new SurfaceStateColors(
+                    background,
+                    AJutColorHelper.PickReadableForeground(background, preferLight, kForegroundHysteresis),
+                    AJutColorHelper.AdjustLightness(background, borderDelta)
+                );
+            }
+        }
+    }
+}

--- a/sandbox/winui/AJutShowRoomWinUI.csproj
+++ b/sandbox/winui/AJutShowRoomWinUI.csproj
@@ -14,6 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <None Remove="ColorParseExample.xaml" />
+    <None Remove="BrushButtonExample.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -62,6 +63,9 @@
   </ItemGroup>
   <ItemGroup>
     <Page Update="ColorParseExample.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="BrushButtonExample.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Update="Themes\DarkTheme.xaml">

--- a/sandbox/winui/BrushButtonExample.xaml
+++ b/sandbox/winui/BrushButtonExample.xaml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="AJutShowRoomWinUI.BrushButtonExample"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:AJutShowRoomWinUI"
+    xmlns:ajut="using:AJut.UX.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Name="Self">
+
+    <ScrollViewer VerticalScrollMode="Enabled" Padding="16">
+        <StackPanel Spacing="20">
+
+            <TextBlock Text="BrushButton" FontSize="18" FontWeight="Bold"/>
+            <TextBlock TextWrapping="Wrap" Opacity="0.7"
+                       Text="Per-state brushes are plain dependency properties - set, bind, or {ThemeResource} any of them. Every slot defaults to the standard WinUI button brush, so an untouched button behaves normally and you override only the slots you want."/>
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <ajut:BrushButton Content="Default"/>
+                <ajut:BrushButton Content="Custom Red"
+                                  NormalBackground="#C0392B" PointerOverBackground="#E04A3A" PressedBackground="#96281B"
+                                  NormalForeground="White" PointerOverForeground="White" PressedForeground="White"/>
+                <ajut:BrushButton Content="Border Only"
+                                  BorderThickness="2"
+                                  NormalBorderBrush="#2ECC71" PointerOverBorderBrush="#58D68D" PressedBorderBrush="#1E8449"/>
+                <ajut:BrushButton Content="Disabled" IsEnabled="False"/>
+            </StackPanel>
+
+            <TextBlock Text="AutoBrushButton" FontSize="18" FontWeight="Bold" Margin="0,8,0,0"/>
+            <TextBlock TextWrapping="Wrap" Opacity="0.7"
+                       Text="One accent color in, a coherent readable palette out - a contrasting foreground, a visible border, and the pointer-over / pressed / disabled variants."/>
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <ajut:AutoBrushButton Content="Dark Red" PropagatedAccentColor="DarkRed"/>
+                <ajut:AutoBrushButton Content="Blue" PropagatedAccentColor="#0D83D8"/>
+                <ajut:AutoBrushButton Content="Green" PropagatedAccentColor="#2ECC71"/>
+                <ajut:AutoBrushButton Content="Gold" PropagatedAccentColor="Gold"/>
+                <ajut:AutoBrushButton Content="Disabled" PropagatedAccentColor="DarkRed" IsEnabled="False"/>
+            </StackPanel>
+
+            <TextBlock Text="Live accent" FontSize="18" FontWeight="Bold" Margin="0,8,0,0"/>
+            <StackPanel Orientation="Horizontal" Spacing="20">
+                <ColorPicker x:Name="AccentPicker" ColorChanged="OnAccentPickerColorChanged" IsAlphaEnabled="False" IsMoreButtonVisible="False"/>
+                <StackPanel Spacing="12" VerticalAlignment="Center">
+                    <ajut:AutoBrushButton Content="Pick my color" PropagatedAccentColor="{x:Bind DemoAccent, Mode=OneWay}" Padding="20,10"/>
+                    <ajut:AutoBrushButton Content="Disabled too" PropagatedAccentColor="{x:Bind DemoAccent, Mode=OneWay}" Padding="20,10" IsEnabled="False"/>
+                </StackPanel>
+            </StackPanel>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/sandbox/winui/BrushButtonExample.xaml
+++ b/sandbox/winui/BrushButtonExample.xaml
@@ -10,7 +10,7 @@
     mc:Ignorable="d"
     x:Name="Self">
 
-    <ScrollViewer VerticalScrollMode="Enabled" Padding="16">
+    <ScrollViewer VerticalScrollMode="Enabled" HorizontalScrollMode="Disabled" HorizontalScrollBarVisibility="Disabled" Padding="16">
         <StackPanel Spacing="20">
 
             <TextBlock Text="BrushButton" FontSize="18" FontWeight="Bold"/>

--- a/sandbox/winui/BrushButtonExample.xaml.cs
+++ b/sandbox/winui/BrushButtonExample.xaml.cs
@@ -1,0 +1,28 @@
+namespace AJutShowRoomWinUI
+{
+    using Microsoft.UI.Xaml;
+    using Microsoft.UI.Xaml.Controls;
+    using Windows.UI;
+    using DPUtils = AJut.UX.DPUtils<BrushButtonExample>;
+
+    public sealed partial class BrushButtonExample : UserControl
+    {
+        public BrushButtonExample ()
+        {
+            this.InitializeComponent();
+            this.AccentPicker.Color = this.DemoAccent;
+        }
+
+        public static readonly DependencyProperty DemoAccentProperty = DPUtils.Register(_ => _.DemoAccent, Color.FromArgb(255, 139, 0, 0));
+        public Color DemoAccent
+        {
+            get => (Color)this.GetValue(DemoAccentProperty);
+            set => this.SetValue(DemoAccentProperty, value);
+        }
+
+        private void OnAccentPickerColorChanged (ColorPicker sender, ColorChangedEventArgs args)
+        {
+            this.DemoAccent = args.NewColor;
+        }
+    }
+}

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -976,6 +976,16 @@
                         </TabViewItem.Content>
                     </TabViewItem>
 
+                    <!-- ===[ Brush Buttons ]================================================== -->
+                    <TabViewItem Header="Brush Buttons" IsClosable="False" VerticalContentAlignment="Stretch">
+                        <TabViewItem.IconSource>
+                            <SymbolIconSource Symbol="Highlight"/>
+                        </TabViewItem.IconSource>
+                        <TabViewItem.Content>
+                            <local:BrushButtonExample/>
+                        </TabViewItem.Content>
+                    </TabViewItem>
+
                 </TabView>
             </Border>
         </Grid>

--- a/sandbox/wpf/UI/Controls/BrushButtonExample.xaml
+++ b/sandbox/wpf/UI/Controls/BrushButtonExample.xaml
@@ -1,0 +1,49 @@
+<UserControl x:Class="TheAJutShowRoom.UI.Controls.BrushButtonExample"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="clr-namespace:TheAJutShowRoom.UI.Controls"
+             xmlns:ajut="clr-namespace:AJut.UX.Controls;assembly=AJut.UX.Wpf"
+             mc:Ignorable="d"
+             d:DesignHeight="450" d:DesignWidth="800"
+             x:Name="Self">
+    <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" Padding="16">
+        <StackPanel>
+            <TextBlock Text="BrushButton" FontSize="18" FontWeight="Bold"/>
+            <TextBlock TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"
+                       Text="Per-state brushes are plain dependency properties - set, bind, or {DynamicResource} any of them. Every slot defaults to an AJut button brush, so an untouched button behaves normally and you override only the slots you want."/>
+            <WrapPanel>
+                <ajut:BrushButton Content="Default" Margin="0,0,8,8"/>
+                <ajut:BrushButton Content="Custom Red" Margin="0,0,8,8"
+                                  NormalBackground="#C0392B" PointerOverBackground="#E04A3A" PressedBackground="#96281B"
+                                  NormalForeground="White" PointerOverForeground="White" PressedForeground="White"/>
+                <ajut:BrushButton Content="Border Only" Margin="0,0,8,8" BorderThickness="2"
+                                  NormalBorderBrush="#2ECC71" PointerOverBorderBrush="#58D68D" PressedBorderBrush="#1E8449"/>
+                <ajut:BrushButton Content="Disabled" Margin="0,0,8,8" IsEnabled="False"/>
+            </WrapPanel>
+
+            <TextBlock Text="AutoBrushButton" FontSize="18" FontWeight="Bold" Margin="0,16,0,0"/>
+            <TextBlock TextWrapping="Wrap" Opacity="0.7" Margin="0,0,0,8"
+                       Text="One accent color in, a coherent readable palette out - a contrasting foreground, a visible border, and the mouse-over / pressed / disabled variants."/>
+            <WrapPanel>
+                <ajut:AutoBrushButton Content="Dark Red" Margin="0,0,8,8" PropagatedAccentColor="DarkRed"/>
+                <ajut:AutoBrushButton Content="Blue" Margin="0,0,8,8" PropagatedAccentColor="#0D83D8"/>
+                <ajut:AutoBrushButton Content="Green" Margin="0,0,8,8" PropagatedAccentColor="#186E11"/>
+                <ajut:AutoBrushButton Content="Gold" Margin="0,0,8,8" PropagatedAccentColor="Gold"/>
+                <ajut:AutoBrushButton Content="Disabled" Margin="0,0,8,8" PropagatedAccentColor="DarkRed" IsEnabled="False"/>
+            </WrapPanel>
+
+            <TextBlock Text="Live accent" FontSize="18" FontWeight="Bold" Margin="0,16,0,0"/>
+            <StackPanel Orientation="Horizontal" Margin="0,8,0,0">
+                <ajut:ColorValueEditControl x:Name="AccentMaker" EditColor="#186E11" VerticalAlignment="Top"/>
+                <StackPanel Margin="20,0,0,0" VerticalAlignment="Center">
+                    <ajut:AutoBrushButton Content="Pick my color" Padding="20,10" Margin="0,0,0,8"
+                                          PropagatedAccentColor="{Binding ElementName=AccentMaker, Path=EditColor}"/>
+                    <ajut:AutoBrushButton Content="Disabled too" Padding="20,10" IsEnabled="False"
+                                          PropagatedAccentColor="{Binding ElementName=AccentMaker, Path=EditColor}"/>
+                </StackPanel>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/sandbox/wpf/UI/Controls/BrushButtonExample.xaml.cs
+++ b/sandbox/wpf/UI/Controls/BrushButtonExample.xaml.cs
@@ -1,0 +1,12 @@
+namespace TheAJutShowRoom.UI.Controls
+{
+    using System.Windows.Controls;
+
+    public partial class BrushButtonExample : UserControl
+    {
+        public BrushButtonExample ()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/sandbox/wpf/UI/Pages/ControlsOverviewPage.xaml
+++ b/sandbox/wpf/UI/Pages/ControlsOverviewPage.xaml
@@ -18,6 +18,9 @@
         <TabItem Header="BumpStack">
             <ctrls:BumpStackControlExample />
         </TabItem>
+        <TabItem Header="BrushButton">
+            <ctrls:BrushButtonExample />
+        </TabItem>
         <TabItem Header="BusyWait">
             <StackPanel>
                 <ajut:BusyWait Content="A busy wait" SpinnerDock="Right"

--- a/test/AJut.UX.Tests/ColorMathTests.cs
+++ b/test/AJut.UX.Tests/ColorMathTests.cs
@@ -1,0 +1,186 @@
+namespace AJut.UX.Tests
+{
+    using System;
+    using AJut.UX.Helpers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ColorMathTests
+    {
+        // WCAG AA for normal text. PickReadableForeground anchors at pure white/black, so its worst case
+        // (a background on the luminance crossover) still clears this.
+        private const double kReadableContrast = 4.5;
+        // Hover/pressed hold the resting foreground polarity (no flip), which can trade some contrast on
+        // borderline accents; they should still clear WCAG AA for large text.
+        private const double kReadableLargeContrast = 3.0;
+
+        [TestMethod]
+        public void CM_RgbToHsl_KnownColors ()
+        {
+            _DoAssert(ColorArgb.FromRgb(255, 0, 0), 0, 1, 0.5);     // red
+            _DoAssert(ColorArgb.FromRgb(0, 255, 0), 120, 1, 0.5);   // green
+            _DoAssert(ColorArgb.FromRgb(0, 0, 255), 240, 1, 0.5);   // blue
+            _DoAssert(ColorArgb.FromRgb(255, 255, 255), 0, 0, 1.0); // white
+            _DoAssert(ColorArgb.FromRgb(0, 0, 0), 0, 0, 0.0);       // black
+
+            static void _DoAssert (ColorArgb color, double hue, double saturation, double lightness)
+            {
+                HslColor hsl = AJutColorHelper.RgbToHsl(color);
+                Assert.AreEqual(hue, hsl.Hue, 0.5);
+                Assert.AreEqual(saturation, hsl.Saturation, 0.01);
+                Assert.AreEqual(lightness, hsl.Lightness, 0.01);
+            }
+        }
+
+        [TestMethod]
+        public void CM_HslRoundTrip_StaysWithinTolerance ()
+        {
+            _DoAssert(ColorArgb.FromRgb(139, 0, 0));      // dark red
+            _DoAssert(ColorArgb.FromRgb(13, 131, 216));   // AJut primary highlight
+            _DoAssert(ColorArgb.FromRgb(204, 107, 80));
+            _DoAssert(ColorArgb.FromRgb(33, 150, 243));
+            _DoAssert(new ColorArgb(128, 70, 200, 30));   // carries alpha through untouched
+
+            static void _DoAssert (ColorArgb color)
+            {
+                ColorArgb back = AJutColorHelper.HslToRgb(AJutColorHelper.RgbToHsl(color), color.A);
+                Assert.AreEqual(color.A, back.A);
+                Assert.IsTrue(Math.Abs(color.R - back.R) <= 2, $"R off: {color.R} vs {back.R}");
+                Assert.IsTrue(Math.Abs(color.G - back.G) <= 2, $"G off: {color.G} vs {back.G}");
+                Assert.IsTrue(Math.Abs(color.B - back.B) <= 2, $"B off: {color.B} vs {back.B}");
+            }
+        }
+
+        [TestMethod]
+        public void CM_Luminance_BlackAndWhiteAnchors ()
+        {
+            Assert.AreEqual(0.0, AJutColorHelper.GetRelativeLuminance(ColorArgb.FromRgb(0, 0, 0)), 0.0001);
+            Assert.AreEqual(1.0, AJutColorHelper.GetRelativeLuminance(ColorArgb.FromRgb(255, 255, 255)), 0.0001);
+        }
+
+        [TestMethod]
+        public void CM_ContrastRatio_BlackOnWhiteIsMax ()
+        {
+            double ratio = AJutColorHelper.GetContrastRatio(ColorArgb.FromRgb(0, 0, 0), ColorArgb.FromRgb(255, 255, 255));
+            Assert.AreEqual(21.0, ratio, 0.1);
+        }
+
+        [TestMethod]
+        public void CM_PickReadableForeground_ContrastsBackground ()
+        {
+            _DoAssert(ColorArgb.FromRgb(139, 0, 0));     // dark red -> light fg
+            _DoAssert(ColorArgb.FromRgb(255, 255, 255)); // white -> dark fg
+            _DoAssert(ColorArgb.FromRgb(13, 131, 216));
+            _DoAssert(ColorArgb.FromRgb(255, 235, 59));  // bright yellow -> dark fg
+            _DoAssert(ColorArgb.FromRgb(128, 128, 128)); // mid gray (near the crossover)
+
+            static void _DoAssert (ColorArgb background)
+            {
+                ColorArgb foreground = AJutColorHelper.PickReadableForeground(background);
+                double ratio = AJutColorHelper.GetContrastRatio(background, foreground);
+                Assert.IsTrue(ratio >= kReadableContrast, $"Contrast only {ratio:0.0} for background {background}");
+            }
+        }
+
+        [TestMethod]
+        public void CM_PickReadableForeground_DarkRedGivesLight ()
+        {
+            ColorArgb foreground = AJutColorHelper.PickReadableForeground(ColorArgb.FromRgb(139, 0, 0));
+            Assert.IsFalse(AJutColorHelper.IsDark(foreground), "Expected a light foreground for dark red");
+        }
+
+        [TestMethod]
+        public void CM_AdjustLightness_MovesAndClamps ()
+        {
+            ColorArgb mid = ColorArgb.FromRgb(100, 100, 100);
+            Assert.IsTrue(AJutColorHelper.GetRelativeLuminance(AJutColorHelper.Lighten(mid, 0.2)) > AJutColorHelper.GetRelativeLuminance(mid));
+            Assert.IsTrue(AJutColorHelper.GetRelativeLuminance(AJutColorHelper.Darken(mid, 0.2)) < AJutColorHelper.GetRelativeLuminance(mid));
+
+            // Lightening white stays white, darkening black stays black.
+            Assert.AreEqual(255, AJutColorHelper.Lighten(ColorArgb.FromRgb(255, 255, 255), 0.5).R);
+            Assert.AreEqual(0, AJutColorHelper.Darken(ColorArgb.FromRgb(0, 0, 0), 0.5).R);
+        }
+
+        [TestMethod]
+        public void CM_ScaleSaturation_ZeroIsGray ()
+        {
+            ColorArgb gray = AJutColorHelper.ScaleSaturation(ColorArgb.FromRgb(200, 50, 50), 0.0);
+            Assert.AreEqual(gray.R, gray.G);
+            Assert.AreEqual(gray.G, gray.B);
+        }
+
+        [TestMethod]
+        public void CM_Blend_MidpointAndEndpoints ()
+        {
+            ColorArgb mid = AJutColorHelper.Blend(ColorArgb.FromRgb(0, 0, 0), ColorArgb.FromRgb(255, 255, 255), 0.5);
+            Assert.IsTrue(Math.Abs(mid.R - 128) <= 1);
+            Assert.IsTrue(Math.Abs(mid.G - 128) <= 1);
+            Assert.IsTrue(Math.Abs(mid.B - 128) <= 1);
+
+            ColorArgb a = new ColorArgb(255, 10, 20, 30);
+            ColorArgb b = new ColorArgb(100, 200, 150, 90);
+            Assert.AreEqual(a, AJutColorHelper.Blend(a, b, 0.0));
+            Assert.AreEqual(b, AJutColorHelper.Blend(a, b, 1.0));
+        }
+
+        [TestMethod]
+        public void CM_BuildFromAccent_NormalKeepsAccentAndDerivesStates ()
+        {
+            ColorArgb accent = ColorArgb.FromRgb(139, 0, 0); // dark red
+            InteractiveSurfaceColors palette = InteractiveSurfaceColors.BuildFromAccent(accent);
+
+            Assert.AreEqual(accent, palette.Normal.Background);
+            Assert.IsTrue(AJutColorHelper.GetContrastRatio(palette.Normal.Background, palette.Normal.Foreground) >= kReadableContrast);
+            Assert.AreNotEqual(palette.Normal.Background, palette.PointerOver.Background);
+            Assert.AreNotEqual(palette.Normal.Background, palette.Pressed.Background);
+            Assert.IsTrue(palette.Disabled.Background.A < 255, "Disabled background should be faded");
+        }
+
+        [TestMethod]
+        public void CM_BuildFromAccent_AllInteractiveStatesReadable ()
+        {
+            foreach (ColorArgb accent in _SampleAccents())
+            {
+                InteractiveSurfaceColors palette = InteractiveSurfaceColors.BuildFromAccent(accent);
+
+                // Resting state always uses the accent's best polarity, so it clears AA.
+                double restRatio = AJutColorHelper.GetContrastRatio(palette.Normal.Background, palette.Normal.Foreground);
+                Assert.IsTrue(restRatio >= kReadableContrast, $"Rest contrast only {restRatio:0.0} for accent {accent}");
+
+                // Hover/pressed hold that polarity (no flip), so they clear at least AA-large.
+                _AssertReadableLarge(palette.PointerOver, accent);
+                _AssertReadableLarge(palette.Pressed, accent);
+            }
+
+            static void _AssertReadableLarge (SurfaceStateColors state, ColorArgb accent)
+            {
+                double ratio = AJutColorHelper.GetContrastRatio(state.Background, state.Foreground);
+                Assert.IsTrue(ratio >= kReadableLargeContrast, $"Contrast only {ratio:0.0} for accent {accent}");
+            }
+        }
+
+        [TestMethod]
+        public void CM_BuildFromAccent_ForegroundPolarityHeldAcrossStates ()
+        {
+            // The reported bug: #186E11 went white text at rest then flipped to black on hover/press.
+            // Foreground polarity must be identical across rest / hover / pressed for every accent.
+            foreach (ColorArgb accent in _SampleAccents())
+            {
+                InteractiveSurfaceColors palette = InteractiveSurfaceColors.BuildFromAccent(accent);
+                bool restIsLight = !AJutColorHelper.IsDark(palette.Normal.Foreground);
+                Assert.AreEqual(restIsLight, !AJutColorHelper.IsDark(palette.PointerOver.Foreground), $"Hover foreground flipped for accent {accent}");
+                Assert.AreEqual(restIsLight, !AJutColorHelper.IsDark(palette.Pressed.Foreground), $"Pressed foreground flipped for accent {accent}");
+            }
+        }
+
+        private static ColorArgb[] _SampleAccents () => new[]
+        {
+            ColorArgb.FromRgb(139, 0, 0),    // dark red
+            ColorArgb.FromRgb(24, 110, 17),  // #186E11 - the reported flip case
+            ColorArgb.FromRgb(13, 131, 216), // AJut primary highlight
+            ColorArgb.FromRgb(255, 235, 59), // bright yellow
+            ColorArgb.FromRgb(46, 204, 113), // green
+            ColorArgb.FromRgb(128, 128, 128),// mid gray
+        };
+    }
+}


### PR DESCRIPTION
I was sick of having to do style overrides to make something like a one-off red button.  The `BrushButton` is just an easy to set, all the state colors laid out (normal/hover/pressed/disabled - for background/border/foreground). The `AutoBrushButton` let'ss you specify a `PropagatedAccentColor` and then doing some basic color math, we can find complimentary border & foreground colors.