### PR TITLE
Memory leak fixes: Drag drop insertion widget / testbed (winui only)

### DIFF
--- a/AJut.sln
+++ b/AJut.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31912.275
+# Visual Studio Version 18
+VisualStudioVersion = 18.7.11911.148 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "libs", "libs", "{7C5EB0C7-99CC-4649-9FCB-6BA45E857DE5}"
 EndProject

--- a/libs/AJut.UX.WinUI3/Controls/DockZone.cs
+++ b/libs/AJut.UX.WinUI3/Controls/DockZone.cs
@@ -1348,6 +1348,33 @@ namespace AJut.UX.Controls
             m_dropOverlay = grid;
         }
 
+        // Severs the drop-overlay back-references so a driver widget that lingers (its native
+        // peer can outlive the logical tree) can no longer root this DockZone and, through it,
+        // everything docked in it. Called from DockingManager.Dispose. Safe to call while content
+        // is still docked - the overlay is only used mid-drag, never at teardown - and idempotent.
+        internal void ReleaseDropOverlay()
+        {
+            foreach (var widget in new[] { m_overlayLeft, m_overlayTop, m_overlayRight, m_overlayBottom, m_overlayCenter })
+            {
+                if (widget != null)
+                {
+                    widget.InsertionZone = null;
+                }
+            }
+
+            if (m_dropOverlay != null)
+            {
+                m_dropOverlay.Children.Clear();
+                if (this.PART_Root?.Parent is Grid outerGrid)
+                {
+                    outerGrid.Children.Remove(m_dropOverlay);
+                }
+            }
+
+            m_overlayLeft = m_overlayTop = m_overlayRight = m_overlayBottom = m_overlayCenter = null;
+            m_dropOverlay = null;
+        }
+
         private void OnIsDirectDropTargetChanged(DependencyPropertyChangedEventArgs<bool> e)
         {
             if (m_dropOverlay == null)

--- a/libs/AJut.UX.WinUI3/Docking/DockingManager.cs
+++ b/libs/AJut.UX.WinUI3/Docking/DockingManager.cs
@@ -123,6 +123,14 @@ namespace AJut.UX.Docking
             {
                 zone.Loaded -= this.MainWindowDockZone_Loaded;
                 zone.Unloaded -= this.MainWindowDockZone_Unloaded;
+
+                // The drop overlay's 5 DockDropInsertionDriverWidgets each hold InsertionZone = their
+                // zone. A widget whose native peer lingers past teardown would otherwise root the whole
+                // docked graph through that back-ref. Sever it on every zone in the tree, not just root.
+                foreach (DockZone treeZone in TreeTraversal<DockZone>.All(zone))
+                {
+                    treeZone.ReleaseDropOverlay();
+                }
             }
 
             m_rootDockZones.Clear();

--- a/sandbox/winui/AJutShowRoomWinUI.csproj
+++ b/sandbox/winui/AJutShowRoomWinUI.csproj
@@ -15,6 +15,10 @@
   <ItemGroup>
     <None Remove="ColorParseExample.xaml" />
     <None Remove="BrushButtonExample.xaml" />
+    <None Remove="UseCaseTest\ItemsDockPanel.xaml" />
+    <None Remove="UseCaseTest\PropertiesDockPanel.xaml" />
+    <None Remove="UseCaseTest\UseCaseEditorPage.xaml" />
+    <None Remove="UseCaseTest\UseCaseLandingPage.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -66,6 +70,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Update="BrushButtonExample.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="UseCaseTest\ItemsDockPanel.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="UseCaseTest\PropertiesDockPanel.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="UseCaseTest\UseCaseEditorPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Update="UseCaseTest\UseCaseLandingPage.xaml">
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Update="Themes\DarkTheme.xaml">

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -977,6 +977,19 @@
                         </TabViewItem.Content>
                     </TabViewItem>
 
+                    <!-- ===[ Use-Case Leak Test ]================================================ -->
+                    <!-- A realistic editor scenario (docked tools + property grid) reached by type-based
+                         page nav with no page caching, so navigating away tears the editor down. Used to
+                         confirm teardown leaks before fixing them. See the UseCaseTest folder. -->
+                    <TabViewItem Header="Use-Case Leak Test" IsClosable="False" VerticalContentAlignment="Stretch">
+                        <TabViewItem.IconSource>
+                            <SymbolIconSource Symbol="Find"/>
+                        </TabViewItem.IconSource>
+                        <TabViewItem.Content>
+                            <Frame x:Name="UseCaseFrame" Loaded="UseCaseTab_OnLoaded"/>
+                        </TabViewItem.Content>
+                    </TabViewItem>
+
                     <!-- ===[ Brush Buttons ]================================================== -->
                     <TabViewItem Header="Brush Buttons" IsClosable="False" VerticalContentAlignment="Stretch">
                         <TabViewItem.IconSource>

--- a/sandbox/winui/MainWindow.xaml
+++ b/sandbox/winui/MainWindow.xaml
@@ -912,6 +912,7 @@
                                         <Button Content="Probe x5 (open/close cycles)" Click="LeakProbe_OnCycleClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
                                         <Button Content="Dock leak - child window" Click="LeakProbe_OnChildWindowDockingClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
                                         <Button Content="Dock leak - main window (control)" Click="LeakProbe_OnMainWindowDockingClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
+                                        <Button Content="Dock overlay severed on Dispose (mechanism)" Click="LeakProbe_OnDropOverlaySeveredClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
                                         <Button Content="Probe PropertyGrid" Click="LeakProbe_OnPropertyGridClicked" MinWidth="300" HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"/>
                                     </StackPanel>
 

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace AJutShowRoomWinUI
         // ===========[ Dock Zone test state ]============================================
         private DockingManager m_dockingManager;
         private bool m_dockZoneInitialized = false;
+        private bool m_useCaseInitialized = false;
 
         public MainWindow (WindowManager manager, AppThemeManager themeManager)
         {
@@ -558,6 +559,22 @@ namespace AJutShowRoomWinUI
                 // Hidden infra panel - always present in layout, never in menu/toolbar
                 m_dockingManager.DockNewPanel<HiddenInfraShowRoomPanel>(zone);
             }
+        }
+
+        // ===========[ Use-Case Leak Test tab ]==========================================
+
+        private void UseCaseTab_OnLoaded (object sender, RoutedEventArgs e)
+        {
+            if (m_useCaseInitialized)
+            {
+                return;
+            }
+
+            m_useCaseInitialized = true;
+
+            // Pass this window through as the nav parameter so the editor's DockingManager roots to
+            // the real root window (the editor lives inside this Frame, like a host editor page).
+            this.UseCaseFrame.Navigate(typeof(UseCaseTest.UseCaseLandingPage), this);
         }
 
         private void DockZone_OnSaveLayoutClicked(object sender, RoutedEventArgs e)

--- a/sandbox/winui/MainWindow.xaml.cs
+++ b/sandbox/winui/MainWindow.xaml.cs
@@ -757,6 +757,66 @@ namespace AJutShowRoomWinUI
             }
         }
 
+        // Deterministic mechanism check for the drop-overlay back-ref fix. The native-peer pin that
+        // makes the leak bite cannot be reproduced headless, but the FIX is exact and testable: after
+        // DockingManager.Dispose, every DockDropInsertionDriverWidget must have had its InsertionZone
+        // back-ref nulled and been detached from the zone's outer grid. This builds a real docked graph
+        // (so templates apply and the 5 widgets per zone exist), grabs them while live, disposes, and
+        // asserts the sever. Fails before the fix (InsertionZone still points at the zone), passes after.
+        private async void LeakProbe_OnDropOverlaySeveredClicked (object sender, RoutedEventArgs e)
+        {
+            var button = sender as Button;
+            if (button != null) { button.IsEnabled = false; }
+            try
+            {
+                var probe = this.LeakProbe_BuildMainWindowDocking();
+
+                // Wait for the page to load so each DockZone applies its template and BuildDropOverlay
+                // builds the driver widgets - the things we are about to assert get severed.
+                await LeakProbe_WaitForLoaded(probe.EditorPage, 3000);
+                await Task.Delay(200);
+
+                // Collect the driver widgets across the whole zone tree while they are still live in the
+                // overlay. Hold strong refs so Dispose can't collect them out from under the assertion -
+                // this probe checks the back-ref is nulled, not whether the widget itself collects.
+                var widgets = LeakProbe_CollectDescendants<AJut.UX.Controls.DockDropInsertionDriverWidget>(probe.RootZone);
+                int built = widgets.Count;
+                int boundBefore = widgets.Count(w => w.InsertionZone != null);
+
+                // The operation under test.
+                probe.Manager.Dispose();
+
+                int stillBound = widgets.Count(w => w.InsertionZone != null);
+                int stillParented = widgets.Count(w => VisualTreeHelper.GetParent(w) != null);
+
+                // Assertion done - drop the host parenting and strong refs.
+                if (probe.MainHost != null) { probe.MainHost.Child = null; }
+                if (probe.EditorPage is ContentControl page) { page.Content = null; }
+                widgets.Clear();
+                probe = null;
+
+                string result;
+                if (built == 0)
+                {
+                    result = "INCONCLUSIVE - no drop-overlay widgets realized (template never applied?)";
+                }
+                else if (stillBound == 0 && stillParented == 0)
+                {
+                    result = $"PASS - all {built} driver widgets severed (InsertionZone null) and detached after Dispose (boundBefore={boundBefore})";
+                }
+                else
+                {
+                    result = $"FAIL - after Dispose: {stillBound}/{built} still hold InsertionZone, {stillParented}/{built} still parented (boundBefore={boundBefore})";
+                }
+
+                this.LeakProbe_AppendOutput("Dock overlay severed (mechanism)", result);
+            }
+            finally
+            {
+                if (button != null) { button.IsEnabled = true; }
+            }
+        }
+
         // Builds the docking graph inside a fresh child Window (RootWindow stays the main window).
         private static DockingLeakProbe LeakProbe_BuildChildWindowDocking (Window mainRoot)
         {
@@ -969,6 +1029,32 @@ namespace AJutShowRoomWinUI
             }
 
             return count;
+        }
+
+        private static List<T> LeakProbe_CollectDescendants<T> (DependencyObject root) where T : DependencyObject
+        {
+            var results = new List<T>();
+            LeakProbe_CollectDescendantsInto(root, results);
+            return results;
+        }
+
+        private static void LeakProbe_CollectDescendantsInto<T> (DependencyObject node, List<T> results) where T : DependencyObject
+        {
+            if (node == null)
+            {
+                return;
+            }
+
+            if (node is T match)
+            {
+                results.Add(match);
+            }
+
+            int childCount = VisualTreeHelper.GetChildrenCount(node);
+            for (int i = 0; i < childCount; ++i)
+            {
+                LeakProbe_CollectDescendantsInto(VisualTreeHelper.GetChild(node, i), results);
+            }
         }
 
         // Counts only - the GC happens in LeakProbe_SettleAndCollectAsync before this is called.

--- a/sandbox/winui/UseCaseTest/ItemsDockPanel.xaml
+++ b/sandbox/winui/UseCaseTest/ItemsDockPanel.xaml
@@ -1,0 +1,20 @@
+<UserControl
+    x:Class="AJutShowRoomWinUI.UseCaseTest.ItemsDockPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ajut="using:AJut.UX.Controls">
+
+    <Grid>
+        <ajut:FlatTreeListControl x:Name="ItemsTree"
+                                  IncludeRoot="False"
+                                  StartItemsExpanded="True"
+                                  SelectionMode="Single"
+                                  SelectionChanged="OnTreeSelectionChanged">
+            <ajut:FlatTreeListControl.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Source.NodeName}" VerticalAlignment="Center"/>
+                </DataTemplate>
+            </ajut:FlatTreeListControl.ItemTemplate>
+        </ajut:FlatTreeListControl>
+    </Grid>
+</UserControl>

--- a/sandbox/winui/UseCaseTest/ItemsDockPanel.xaml.cs
+++ b/sandbox/winui/UseCaseTest/ItemsDockPanel.xaml.cs
@@ -1,0 +1,68 @@
+namespace AJutShowRoomWinUI.UseCaseTest
+{
+    using System;
+    using AJut.TypeManagement;
+    using AJut.UX;
+    using AJut.UX.Controls;
+    using AJut.UX.Docking;
+    using Microsoft.UI.Xaml.Controls;
+
+    // ===========[ ItemsDockPanel ]==============================================
+    // Dockable panel that shows the tool tree in a FlatTreeListControl. Raises ItemSelected
+    // when the selected row changes so the host page can route the selected ToolItem to the
+    // properties panel. A dockable panel is built by the manager factory, so the constructor
+    // is parameterless and the tree data is pushed in later via SetTree.
+    [TypeId("UseCaseItemsPanel")]
+    public sealed partial class ItemsDockPanel : UserControl, IDockableDisplayElement
+    {
+        public ItemsDockPanel ()
+        {
+            this.InitializeComponent();
+        }
+
+        // ===========[ Events ]===============================================
+        public event EventHandler<ToolItem> ItemSelected;
+
+        // ===========[ Properties ]===========================================
+        public DockingContentAdapterModel DockingAdapter { get; private set; }
+
+        // Exposed so the host page's leak probe can weak-reference the inner control and
+        // confirm the flat tree (and its store) collects on teardown.
+        public FlatTreeListControl TreeControl => this.ItemsTree;
+
+        // ===========[ IDockableDisplayElement ]==============================
+        public void Setup (DockingContentAdapterModel adapter)
+        {
+            this.DockingAdapter = adapter;
+            adapter.TitleContent = "Items";
+        }
+
+        // ===========[ Public Interface ]=====================================
+        public void SetTree (ToolItemNode root)
+        {
+            this.ItemsTree.Root = root;
+        }
+
+        // Called from the host page's teardown so the tree store drops its source
+        // subscriptions and we stop pointing at the source tree.
+        public void Teardown ()
+        {
+            this.ItemsTree.Root = null;
+        }
+
+        // ===========[ Event Handlers ]=======================================
+        private void OnTreeSelectionChanged (object sender, SelectionChange<FlatTreeItem> e)
+        {
+            ToolItem selected = null;
+            if (e.Added != null && e.Added.Length > 0)
+            {
+                if (e.Added[e.Added.Length - 1].Source is ToolItemNode node)
+                {
+                    selected = node.Item;
+                }
+            }
+
+            this.ItemSelected?.Invoke(this, selected);
+        }
+    }
+}

--- a/sandbox/winui/UseCaseTest/PropertiesDockPanel.xaml
+++ b/sandbox/winui/UseCaseTest/PropertiesDockPanel.xaml
@@ -1,0 +1,34 @@
+<UserControl
+    x:Class="AJutShowRoomWinUI.UseCaseTest.PropertiesDockPanel"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ajut="using:AJut.UX.Controls"
+    xmlns:ajut_pg="using:AJut.UX.PropertyInteraction">
+
+    <Grid>
+        <ajut:PropertyGrid x:Name="PropertyEditor"
+                           RowSpacing="5"
+                           LabelColumnWidth="120"
+                           PropertyToolTipPlacement="PropertyNameAndValue">
+            <ajut:PropertyGrid.ItemTemplateSelector>
+                <ajut:PropertyGridTemplateSelector>
+                    <ajut:PropertyGridTemplateSelector.Default>
+                        <DataTemplate x:DataType="ajut_pg:PropertyEditTarget">
+                            <TextBox Text="{Binding Path=EditValue, Mode=TwoWay}"
+                                     Background="Transparent" BorderThickness="0"/>
+                        </DataTemplate>
+                    </ajut:PropertyGridTemplateSelector.Default>
+                    <ajut:PropertyGridTemplateSelector.RegisteredTemplates>
+                        <DataTemplate x:Key="Text" x:DataType="ajut_pg:PropertyEditTarget">
+                            <TextBox Text="{Binding Path=EditValue, Mode=TwoWay}"
+                                     Background="Transparent" BorderThickness="0"/>
+                        </DataTemplate>
+                        <DataTemplate x:Key="Single" x:DataType="ajut_pg:PropertyEditTarget">
+                            <ajut:NumericEditor Value="{Binding Path=EditValue, Mode=TwoWay}" TextBoxHeight="22"/>
+                        </DataTemplate>
+                    </ajut:PropertyGridTemplateSelector.RegisteredTemplates>
+                </ajut:PropertyGridTemplateSelector>
+            </ajut:PropertyGrid.ItemTemplateSelector>
+        </ajut:PropertyGrid>
+    </Grid>
+</UserControl>

--- a/sandbox/winui/UseCaseTest/PropertiesDockPanel.xaml.cs
+++ b/sandbox/winui/UseCaseTest/PropertiesDockPanel.xaml.cs
@@ -1,0 +1,47 @@
+namespace AJutShowRoomWinUI.UseCaseTest
+{
+    using AJut.TypeManagement;
+    using AJut.UX.Controls;
+    using AJut.UX.Docking;
+    using Microsoft.UI.Xaml.Controls;
+
+    // ===========[ PropertiesDockPanel ]=========================================
+    // Dockable panel that edits the currently selected ToolItem in a PropertyGrid. The host
+    // page calls ShowItem when the items panel raises a selection change.
+    [TypeId("UseCasePropertiesPanel")]
+    public sealed partial class PropertiesDockPanel : UserControl, IDockableDisplayElement
+    {
+        public PropertiesDockPanel ()
+        {
+            this.InitializeComponent();
+        }
+
+        // ===========[ Properties ]===========================================
+        public DockingContentAdapterModel DockingAdapter { get; private set; }
+
+        // Exposed so the host page's leak probe can weak-reference the grid and confirm it
+        // collects on teardown.
+        public PropertyGrid GridControl => this.PropertyEditor;
+
+        // ===========[ IDockableDisplayElement ]==============================
+        public void Setup (DockingContentAdapterModel adapter)
+        {
+            this.DockingAdapter = adapter;
+            adapter.TitleContent = "Properties";
+        }
+
+        // ===========[ Public Interface ]=====================================
+        public void ShowItem (ToolItem item)
+        {
+            this.PropertyEditor.SingleItemSource = item;
+        }
+
+        // Called from the host page's teardown - drop the edited source and dispose the grid
+        // (PropertyGrid is IDisposable; this is the consumer's half of the teardown contract).
+        public void Teardown ()
+        {
+            this.PropertyEditor.SingleItemSource = null;
+            this.PropertyEditor.Dispose();
+        }
+    }
+}

--- a/sandbox/winui/UseCaseTest/ToolModel.cs
+++ b/sandbox/winui/UseCaseTest/ToolModel.cs
@@ -1,0 +1,75 @@
+namespace AJutShowRoomWinUI.UseCaseTest
+{
+    using AJut;
+    using AJut.Storage;
+    using AJut.UX.PropertyInteraction;
+
+    // ===========[ ToolItem ]====================================================
+    // Stand-in "tool" with a handful of editable properties. When its tree node is
+    // selected in the items panel, this is what the properties panel edits. Implements
+    // NotifyPropertyChanged so edits round-trip live, matching a real editor model.
+    public class ToolItem : NotifyPropertyChanged
+    {
+        private string m_name;
+        private float m_width = 100f;
+        private float m_height = 100f;
+        private string m_notes = string.Empty;
+
+        public ToolItem (string name)
+        {
+            m_name = name;
+        }
+
+        [PGEditor("Text")]
+        public string Name
+        {
+            get => m_name;
+            set => this.SetAndRaiseIfChanged(ref m_name, value);
+        }
+
+        [PGEditor("Single")]
+        public float Width
+        {
+            get => m_width;
+            set => this.SetAndRaiseIfChanged(ref m_width, value);
+        }
+
+        [PGEditor("Single")]
+        public float Height
+        {
+            get => m_height;
+            set => this.SetAndRaiseIfChanged(ref m_height, value);
+        }
+
+        [PGEditor("Text")]
+        public string Notes
+        {
+            get => m_notes;
+            set => this.SetAndRaiseIfChanged(ref m_notes, value);
+        }
+    }
+
+    // ===========[ ToolItemNode ]================================================
+    // The tree-source node behind each row of the items flat tree. Carries a display
+    // name and the ToolItem payload the properties panel edits. ObservableTreeNode gives
+    // the IObservableTreeNode plumbing FlatTreeListControl needs.
+    public class ToolItemNode : ObservableTreeNode<ToolItemNode>
+    {
+        public ToolItemNode (string name, ToolItem item = null)
+        {
+            this.NodeName = name;
+            this.Item = item;
+        }
+
+        public string NodeName { get; }
+
+        public ToolItem Item { get; }
+
+        public ToolItemNode AddChildItem (string name, ToolItem item = null)
+        {
+            var child = new ToolItemNode(name, item);
+            this.InsertChild(this.Children.Count, child);
+            return child;
+        }
+    }
+}

--- a/sandbox/winui/UseCaseTest/UseCaseEditorPage.xaml
+++ b/sandbox/winui/UseCaseTest/UseCaseEditorPage.xaml
@@ -1,0 +1,26 @@
+<Page
+    x:Class="AJutShowRoomWinUI.UseCaseTest.UseCaseEditorPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ajut="using:AJut.UX.Controls">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <!-- Command bar: back to landing + layout save/load -->
+        <StackPanel Grid.Row="0" Orientation="Horizontal" Spacing="8" Margin="8">
+            <Button Content="Back to Landing" Click="OnBackClicked"/>
+            <Button Content="Save Layout" Click="OnSaveLayoutClicked"/>
+            <Button Content="Load Layout" Click="OnLoadLayoutClicked"/>
+            <TextBlock Text="Editor - select a tool on the Items tab to edit it on the Properties tab. Drag a tab to split."
+                       VerticalAlignment="Center" Opacity="0.7" TextWrapping="Wrap"/>
+        </StackPanel>
+
+        <ajut:DockPanelAddRemoveToolbar x:Name="DockToolbar" Grid.Row="1" Margin="8,0,8,0"/>
+        <ajut:DockZone x:Name="EditorDockZone" Grid.Row="2" Margin="8"/>
+    </Grid>
+</Page>

--- a/sandbox/winui/UseCaseTest/UseCaseEditorPage.xaml.cs
+++ b/sandbox/winui/UseCaseTest/UseCaseEditorPage.xaml.cs
@@ -1,0 +1,225 @@
+namespace AJutShowRoomWinUI.UseCaseTest
+{
+    using System.Linq;
+    using AJut.UX.Controls;
+    using AJut.UX.Docking;
+    using Microsoft.UI.Xaml;
+    using Microsoft.UI.Xaml.Controls;
+    using Microsoft.UI.Xaml.Media;
+    using Microsoft.UI.Xaml.Navigation;
+
+    // ===========[ UseCaseEditorPage ]===========================================
+    // The editor surface, mimicking a real tool editor: a docking experience whose panels are
+    // a flat tree of tools (Items) and a property grid (Properties). Selecting a tool routes it
+    // to the property grid. The page builds the whole graph on load and tears it ALL down on
+    // navigate-away (manager.Dispose + panel teardown + unhook), then records weak references so
+    // the landing page's probe can confirm none of it survived. This is the deterministic
+    // open/close cycle that a host hits when navigating in and out of an editor.
+
+    public sealed partial class UseCaseEditorPage : Page
+    {
+        // ===========[ Fields ]===============================================
+        private Window m_hostWindow;
+        private DockingManager m_manager;
+        private ItemsDockPanel m_itemsPanel;
+        private PropertiesDockPanel m_propertiesPanel;
+        private ToolItemNode m_treeRoot;
+
+        // ===========[ Construction ]=========================================
+        public UseCaseEditorPage ()
+        {
+            this.InitializeComponent();
+            this.Loaded += this.OnEditorLoaded;
+        }
+
+        // ===========[ Navigation ]===========================================
+        protected override void OnNavigatedTo (NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            m_hostWindow = e.Parameter as Window;
+        }
+
+        protected override void OnNavigatedFrom (NavigationEventArgs e)
+        {
+            base.OnNavigatedFrom(e);
+            this.Loaded -= this.OnEditorLoaded;
+            this.TeardownEditor();
+        }
+
+        // ===========[ Setup / Teardown ]=====================================
+        private void OnEditorLoaded (object sender, RoutedEventArgs e)
+        {
+            // One-shot: the graph is built once per navigation onto this page.
+            this.Loaded -= this.OnEditorLoaded;
+            if (m_manager != null || m_hostWindow == null)
+            {
+                return;
+            }
+
+            m_manager = new DockingManager(m_hostWindow, "usecase-editor-dock");
+            m_manager.RegisterDisplayFactory<ItemsDockPanel>();
+            m_manager.RegisterDisplayFactory<PropertiesDockPanel>();
+            this.DockToolbar.DockingManager = m_manager;
+            m_manager.RegisterMainWindowRootDockZones(this.EditorDockZone);
+
+            DockZoneViewModel zone = m_manager.FindFirstAvailableDockZone();
+            if (zone != null)
+            {
+                m_itemsPanel = m_manager.DockNewPanel<ItemsDockPanel>(zone);
+                m_propertiesPanel = m_manager.DockNewPanel<PropertiesDockPanel>(zone);
+            }
+
+            m_treeRoot = BuildSampleTree();
+            m_itemsPanel?.SetTree(m_treeRoot);
+
+            if (m_itemsPanel != null)
+            {
+                m_itemsPanel.ItemSelected += this.OnItemSelected;
+            }
+
+            // Seed the property grid with the first tool so it realizes immediately.
+            this.ShowItem(this.FirstTool());
+        }
+
+        private void TeardownEditor ()
+        {
+            if (m_manager == null)
+            {
+                return;
+            }
+
+            // 1. Drop the cross-panel subscription (its matching += is in OnEditorLoaded).
+            if (m_itemsPanel != null)
+            {
+                m_itemsPanel.ItemSelected -= this.OnItemSelected;
+            }
+
+            // 2. Snapshot proof-of-realization + the inner controls before we dispose anything.
+            int builtRows = CountDescendants<DockLeafLayout>(this.EditorDockZone);
+            FlatTreeListControl treeControl = m_itemsPanel?.TreeControl;
+            PropertyGrid gridControl = m_propertiesPanel?.GridControl;
+            ToolItem sampleItem = this.FirstTool();
+
+            // 3. Consumer half of teardown: panels release their inner state, then the manager
+            //    disposes (the path the docking-overlay fix and the rest of teardown run through).
+            m_itemsPanel?.Teardown();
+            m_propertiesPanel?.Teardown();
+            this.DockToolbar.DockingManager = null;
+            m_manager.Dispose();
+
+            // 4. Record weak refs to everything that must collect, then drop our strong refs.
+            UseCaseLeakRegistry.CaptureEditorTeardown(
+                this,
+                m_manager,
+                this.EditorDockZone,
+                m_itemsPanel,
+                m_propertiesPanel,
+                treeControl,
+                gridControl,
+                m_treeRoot,
+                sampleItem,
+                builtRows
+            );
+
+            m_manager = null;
+            m_itemsPanel = null;
+            m_propertiesPanel = null;
+            m_treeRoot = null;
+            m_hostWindow = null;
+        }
+
+        // ===========[ Event Handlers ]=======================================
+        private void OnItemSelected (object sender, ToolItem item)
+        {
+            this.ShowItem(item);
+        }
+
+        private void OnBackClicked (object sender, RoutedEventArgs e)
+        {
+            if (this.Frame != null)
+            {
+                // Navigate before teardown runs (Navigate triggers OnNavigatedFrom). Clear the
+                // back stack so the editor page instance isn't held for a back navigation.
+                this.Frame.Navigate(typeof(UseCaseLandingPage), m_hostWindow);
+                this.Frame.BackStack.Clear();
+            }
+        }
+
+        private void OnSaveLayoutClicked (object sender, RoutedEventArgs e)
+        {
+            m_manager?.SaveDockLayoutToPersistentStorage();
+        }
+
+        private void OnLoadLayoutClicked (object sender, RoutedEventArgs e)
+        {
+            if (m_manager != null && m_manager.ReloadDockLayoutFromPersistentStorage())
+            {
+                this.RewireAfterLayoutChange();
+            }
+        }
+
+        // ===========[ Helpers ]==============================================
+
+        // After a layout reload the manager rebuilds fresh panel instances, so re-acquire them,
+        // re-push the tree, and re-wire selection (dropping the subscription to the old instance).
+        private void RewireAfterLayoutChange ()
+        {
+            if (m_itemsPanel != null)
+            {
+                m_itemsPanel.ItemSelected -= this.OnItemSelected;
+            }
+
+            m_itemsPanel = m_manager.EnumerateDisplays().OfType<ItemsDockPanel>().FirstOrDefault();
+            m_propertiesPanel = m_manager.EnumerateDisplays().OfType<PropertiesDockPanel>().FirstOrDefault();
+
+            if (m_itemsPanel != null)
+            {
+                m_itemsPanel.SetTree(m_treeRoot);
+                m_itemsPanel.ItemSelected -= this.OnItemSelected;
+                m_itemsPanel.ItemSelected += this.OnItemSelected;
+            }
+
+            this.ShowItem(this.FirstTool());
+        }
+
+        private void ShowItem (ToolItem item)
+        {
+            m_propertiesPanel?.ShowItem(item);
+        }
+
+        private ToolItem FirstTool ()
+        {
+            return (m_treeRoot != null && m_treeRoot.Children.Count > 0)
+                ? m_treeRoot.Children[0].Item
+                : null;
+        }
+
+        private static ToolItemNode BuildSampleTree ()
+        {
+            var root = new ToolItemNode("(root)") { CanHaveChildren = true };
+            for (int i = 1; i <= 6; ++i)
+            {
+                root.AddChildItem($"Tool {i}", new ToolItem($"Tool {i}"));
+            }
+
+            return root;
+        }
+
+        private static int CountDescendants<T> (DependencyObject root) where T : DependencyObject
+        {
+            if (root == null)
+            {
+                return 0;
+            }
+
+            int count = root is T ? 1 : 0;
+            int childCount = VisualTreeHelper.GetChildrenCount(root);
+            for (int i = 0; i < childCount; ++i)
+            {
+                count += CountDescendants<T>(VisualTreeHelper.GetChild(root, i));
+            }
+
+            return count;
+        }
+    }
+}

--- a/sandbox/winui/UseCaseTest/UseCaseLandingPage.xaml
+++ b/sandbox/winui/UseCaseTest/UseCaseLandingPage.xaml
@@ -1,0 +1,28 @@
+<Page
+    x:Class="AJutShowRoomWinUI.UseCaseTest.UseCaseLandingPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <ScrollViewer Padding="16" VerticalScrollMode="Enabled">
+        <StackPanel Spacing="14" MaxWidth="780" HorizontalAlignment="Left">
+            <TextBlock Text="Use-Case Leak Test" Style="{ThemeResource TitleTextBlockStyle}"/>
+            <TextBlock TextWrapping="Wrap" Opacity="0.85"
+                       Text="This page navigates (by type, no page caching) to an editor built the way a real tool editor is: a docking experience whose panels are a flat tree of tools and a property grid. Selecting a tool edits it. There is an add toolbar plus layout save/load."/>
+            <TextBlock TextWrapping="Wrap" Opacity="0.85"
+                       Text="Open the editor, click around, then come back here (the editor's Back button) and run the probe. The editor tears its whole graph down on navigate-away; the probe forces GC and reports whether anything survived. Repeat the open/come-back cycle a few times before probing to see whether survivors accumulate."/>
+            <StackPanel Orientation="Horizontal" Spacing="8">
+                <Button Content="Open Editor" Click="OnOpenEditorClicked"/>
+                <Button Content="Run Memory Leak Probe" Click="OnRunProbeClicked"/>
+                <Button Content="Reset Probe History" Click="OnResetProbeClicked"/>
+            </StackPanel>
+            <TextBox x:Name="ProbeOutput"
+                     IsReadOnly="True"
+                     AcceptsReturn="True"
+                     TextWrapping="Wrap"
+                     MinHeight="200"
+                     FontFamily="Consolas"
+                     FontSize="12"
+                     PlaceholderText="Probe results appear here (newest first)."/>
+        </StackPanel>
+    </ScrollViewer>
+</Page>

--- a/sandbox/winui/UseCaseTest/UseCaseLandingPage.xaml.cs
+++ b/sandbox/winui/UseCaseTest/UseCaseLandingPage.xaml.cs
@@ -1,0 +1,63 @@
+namespace AJutShowRoomWinUI.UseCaseTest
+{
+    using System;
+    using Microsoft.UI.Xaml;
+    using Microsoft.UI.Xaml.Controls;
+    using Microsoft.UI.Xaml.Navigation;
+
+    // ===========[ UseCaseLandingPage ]==========================================
+    // Entry page for the use-case leak test. Navigates to the editor by type (no page caching,
+    // so leaving the editor releases it) and hosts the leak probe that reports whether prior
+    // editor teardowns fully collected. The host Window arrives as the navigation parameter and
+    // is passed along to the editor so its DockingManager roots to the real window.
+    public sealed partial class UseCaseLandingPage : Page
+    {
+        private Window m_hostWindow;
+
+        public UseCaseLandingPage ()
+        {
+            this.InitializeComponent();
+        }
+
+        protected override void OnNavigatedTo (NavigationEventArgs e)
+        {
+            base.OnNavigatedTo(e);
+            m_hostWindow = e.Parameter as Window;
+        }
+
+        private void OnOpenEditorClicked (object sender, RoutedEventArgs e)
+        {
+            this.Frame?.Navigate(typeof(UseCaseEditorPage), m_hostWindow);
+        }
+
+        private async void OnRunProbeClicked (object sender, RoutedEventArgs e)
+        {
+            var button = sender as Button;
+            if (button != null) { button.IsEnabled = false; }
+            try
+            {
+                string report = await UseCaseLeakRegistry.SettleAndReportAsync();
+                this.AppendOutput(report);
+            }
+            finally
+            {
+                if (button != null) { button.IsEnabled = true; }
+            }
+        }
+
+        private void OnResetProbeClicked (object sender, RoutedEventArgs e)
+        {
+            UseCaseLeakRegistry.Reset();
+            this.AppendOutput("Probe history cleared.");
+        }
+
+        private void AppendOutput (string body)
+        {
+            string stamp = DateTime.Now.ToString("HH:mm:ss");
+            string entry = $"[{stamp}] {body}";
+            this.ProbeOutput.Text = this.ProbeOutput.Text.Length == 0
+                ? entry
+                : entry + "\n\n" + this.ProbeOutput.Text;
+        }
+    }
+}

--- a/sandbox/winui/UseCaseTest/UseCaseLeakRegistry.cs
+++ b/sandbox/winui/UseCaseTest/UseCaseLeakRegistry.cs
@@ -1,0 +1,140 @@
+namespace AJutShowRoomWinUI.UseCaseTest
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.UI.Dispatching;
+
+    // ===========[ UseCaseLeakRegistry ]=========================================
+    // Bridges the editor page's teardown to the landing page's leak probe. When the
+    // editor page navigates away it records weak references to every object that MUST
+    // collect (the page, its docking manager, root zone, both panels, the flat tree +
+    // its store, the property grid, the tree-source root, and a sample tool item). The
+    // landing page later forces a settle + GC and reports which of those survived.
+    //
+    // Everything here is weak by construction, so the registry itself never pins what it
+    // is measuring. Built deliberately self-contained so a consumer can lift the whole
+    // UseCaseTest folder as a starting point for its own teardown regression tests.
+    public static class UseCaseLeakRegistry
+    {
+        private static readonly List<Snapshot> g_snapshots = new List<Snapshot>();
+
+        public static void Reset ()
+        {
+            g_snapshots.Clear();
+        }
+
+        // Called from the editor page's teardown AFTER it has disposed/unhooked everything
+        // and dropped its own strong references. builtRows proves the editor actually
+        // realized (non-zero) so a vacuous run can't read as a pass.
+        public static void CaptureEditorTeardown (
+            object page,
+            object manager,
+            object rootZone,
+            object itemsPanel,
+            object propertiesPanel,
+            object flatTree,
+            object propertyGrid,
+            object treeRoot,
+            object sampleItem,
+            int builtRows)
+        {
+            g_snapshots.Add(new Snapshot
+            {
+                Page = new WeakReference(page),
+                Manager = new WeakReference(manager),
+                RootZone = new WeakReference(rootZone),
+                ItemsPanel = new WeakReference(itemsPanel),
+                PropertiesPanel = new WeakReference(propertiesPanel),
+                FlatTree = new WeakReference(flatTree),
+                PropertyGrid = new WeakReference(propertyGrid),
+                TreeRoot = new WeakReference(treeRoot),
+                SampleItem = new WeakReference(sampleItem),
+                BuiltRows = builtRows,
+            });
+        }
+
+        public static bool HasSnapshots => g_snapshots.Count > 0;
+
+        // Drains the dispatcher and forces a full GC several times, then tallies survivors.
+        public static async Task<string> SettleAndReportAsync ()
+        {
+            if (g_snapshots.Count == 0)
+            {
+                return "INCONCLUSIVE - no editor teardown recorded yet. Open the editor, then come back and probe.";
+            }
+
+            for (int i = 0; i < 6; ++i)
+            {
+                await DrainDispatcherAsync();
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+                await Task.Delay(100);
+            }
+
+            int total = g_snapshots.Count;
+            int pages = 0, managers = 0, zones = 0, itemsPanels = 0, propsPanels = 0;
+            int trees = 0, grids = 0, treeRoots = 0, items = 0, builtRows = 0;
+            foreach (Snapshot s in g_snapshots)
+            {
+                if (s.Page.IsAlive) { ++pages; }
+                if (s.Manager.IsAlive) { ++managers; }
+                if (s.RootZone.IsAlive) { ++zones; }
+                if (s.ItemsPanel.IsAlive) { ++itemsPanels; }
+                if (s.PropertiesPanel.IsAlive) { ++propsPanels; }
+                if (s.FlatTree.IsAlive) { ++trees; }
+                if (s.PropertyGrid.IsAlive) { ++grids; }
+                if (s.TreeRoot.IsAlive) { ++treeRoots; }
+                if (s.SampleItem.IsAlive) { ++items; }
+                builtRows += s.BuiltRows;
+            }
+
+            string detail =
+                $"cycles={total} builtRows={builtRows} | survivors: page={pages} manager={managers} zone={zones} "
+                + $"itemsPanel={itemsPanels} propsPanel={propsPanels} flatTree={trees} propGrid={grids} "
+                + $"treeRoot={treeRoots} toolItem={items}";
+
+            if (builtRows == 0)
+            {
+                return $"INCONCLUSIVE - editor never realized rows (builtRows=0): {detail}";
+            }
+
+            bool leaked = pages > 0 || managers > 0 || zones > 0 || itemsPanels > 0 || propsPanels > 0
+                || trees > 0 || grids > 0 || treeRoots > 0 || items > 0;
+
+            return leaked
+                ? $"FAIL - something survived teardown + GC:\n    {detail}"
+                : $"PASS - everything collected:\n    {detail}";
+        }
+
+        // Completes only after all higher-priority dispatcher work has run (Low runs last),
+        // so deferred WinUI cleanup callbacks have fired before we measure.
+        private static Task DrainDispatcherAsync ()
+        {
+            var done = new TaskCompletionSource();
+            DispatcherQueue queue = DispatcherQueue.GetForCurrentThread();
+            bool enqueued = queue != null && queue.TryEnqueue(DispatcherQueuePriority.Low, () => done.SetResult());
+            if (!enqueued)
+            {
+                done.SetResult();
+            }
+
+            return done.Task;
+        }
+
+        private sealed class Snapshot
+        {
+            public WeakReference Page { get; set; }
+            public WeakReference Manager { get; set; }
+            public WeakReference RootZone { get; set; }
+            public WeakReference ItemsPanel { get; set; }
+            public WeakReference PropertiesPanel { get; set; }
+            public WeakReference FlatTree { get; set; }
+            public WeakReference PropertyGrid { get; set; }
+            public WeakReference TreeRoot { get; set; }
+            public WeakReference SampleItem { get; set; }
+            public int BuiltRows { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
So there was an issue with dock drop insertion widget causing memory to stick around. I realized though I need more comprehensive testing for this kind of thing, so I mimicked one of my apps a little bit to help give a more realistic scenario. More to come - and wpf equivalent is next too, but for now this felt like a win I wanted to capture.