### PR TITLE
More mem leak fixes

### DIFF
--- a/libs/AJut.UX.WinUI3/Controls/DockTearoffContainerPanel.cs
+++ b/libs/AJut.UX.WinUI3/Controls/DockTearoffContainerPanel.cs
@@ -204,6 +204,24 @@ namespace AJut.UX.Controls
             this.UpdateMaximizeRestoreGlyph();
         }
 
+        // Drops the window-level subscriptions this panel and its caption buttons wired in
+        // SetupForWindow. SetupForWindow only ever removes them on a re-setup, which never happens for
+        // a tearoff, so without this the closed window's AppWindow.Changed / Window.Activated invocation
+        // lists keep this panel (and the DockZone graph it hosts) rooted. Called from
+        // DockingManager.DetachTearoffSubscriptions on every tearoff close.
+        public void TeardownWindowHooks()
+        {
+            if (m_appWindow != null)
+            {
+                m_appWindow.Changed -= this.OnAppWindowChanged;
+                m_appWindow = null;
+            }
+
+            // SetupFor(null) unsubscribes each caption button's Window.Activated handler.
+            m_maximizeRestoreButton?.SetupFor(null);
+            m_closeButton?.SetupFor(null);
+        }
+
         // ===========[ Event Handlers ]=======================================
 
         private void OnTitleBarPointerPressed(object sender, PointerRoutedEventArgs e)

--- a/libs/AJut.UX.WinUI3/Controls/DockZone.cs
+++ b/libs/AJut.UX.WinUI3/Controls/DockZone.cs
@@ -67,6 +67,12 @@ namespace AJut.UX.Controls
         private int m_tabReorderSourceIdx = -1;
         private int m_tabReorderTargetIdx = -1;
 
+        // Close buttons built per-rebuild inside the leaf header and each tab. Tracked so their Click
+        // (and the tab button's PointerPressed AddHandler) get unhooked in DetachLayoutSubscriptions -
+        // otherwise each one lingers holding a delegate back to this DockZone after every rebuild.
+        private readonly List<DockCloseButton> m_activeCloseButtons = new();
+        private static readonly PointerEventHandler g_suppressPointerPressedHandler = SuppressPointerPressed;
+
         // ===========[ Construction ]=========================================
         static DockZone()
         {
@@ -334,6 +340,18 @@ namespace AJut.UX.Controls
             {
                 m_tabRightScrollBtn.Click -= this.OnTabScrollRight;
             }
+
+            // Unhook the per-rebuild close buttons (leaf header + each tab). Removing both possible
+            // Click handlers and the tab button's PointerPressed handler is safe - a remove for a
+            // handler a given button never had is a no-op.
+            foreach (var closeBtn in m_activeCloseButtons)
+            {
+                closeBtn.Click -= this.OnHeaderPanelCloseBtnClicked;
+                closeBtn.Click -= this.OnTabCloseBtnClicked;
+                closeBtn.RemoveHandler(UIElement.PointerPressedEvent, g_suppressPointerPressedHandler);
+            }
+
+            m_activeCloseButtons.Clear();
         }
 
         private void BuildEmptyLayout()
@@ -415,6 +433,7 @@ namespace AJut.UX.Controls
                     Tag = selectedAdapter,
                 };
                 headerCloseBtn.Click += this.OnHeaderPanelCloseBtnClicked;
+                m_activeCloseButtons.Add(headerCloseBtn);
 
                 var hGrid = new Grid();
                 hGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
@@ -595,10 +614,11 @@ namespace AJut.UX.Controls
             // drag-start handler is not triggered when clicking the close button.
             tabCloseBtn.AddHandler(
                 UIElement.PointerPressedEvent,
-                (PointerEventHandler)SuppressPointerPressed,
+                g_suppressPointerPressedHandler,
                 handledEventsToo: false
             );
             tabCloseBtn.Click += this.OnTabCloseBtnClicked;
+            m_activeCloseButtons.Add(tabCloseBtn);
 
             var tabInner = new StackPanel { Orientation = Orientation.Horizontal };
             tabInner.Children.Add(tabLabel);

--- a/libs/AJut.UX.WinUI3/Docking/DockingManager.cs
+++ b/libs/AJut.UX.WinUI3/Docking/DockingManager.cs
@@ -131,6 +131,11 @@ namespace AJut.UX.Docking
                 {
                     treeZone.ReleaseDropOverlay();
                 }
+
+                // Terminal teardown of the view-model tree: drop Manager/Parent/UI on every zone VM so a
+                // zone whose native peer outlives this manager can't re-root the (now disposed) manager.
+                // The VM tree is still intact here - CloseAll(force) above only handled tearoff windows.
+                zone.ViewModel?.Teardown();
             }
 
             m_rootDockZones.Clear();
@@ -455,6 +460,35 @@ namespace AJut.UX.Docking
             }
         }
 
+        // Deregister AND permanently tear down a set of closing tearoff root zones: drops them from the
+        // manager's bookkeeping, then severs Manager/Parent/UI on every zone VM in their subtrees so a
+        // surviving zone (e.g. one a native peer outlives) can't keep this manager rooted once it is
+        // disposed. Use this ONLY for genuine closes - the re-home path in RegisterRootDockZones must keep
+        // calling plain DeRegisterRootDockZones, since its VM tree is about to move to a new manager.
+        // Caller must ensure the VM trees are still intact (no prior ForceClose/RequestClose) so Teardown
+        // can walk them; DoTearoffWindowClose, which closes first, tears down separately.
+        private void DeRegisterAndTeardownRootZones(params DockZone[] closingZones)
+        {
+            var closingZoneVMs = closingZones
+                .Where(z => z?.ViewModel != null)
+                .Select(z => z.ViewModel)
+                .ToList();
+
+            this.DeRegisterRootDockZones(closingZones);
+
+            foreach (DockZoneViewModel vm in closingZoneVMs)
+            {
+                // A post-drop close (SilentlyForceCloseTearoffWindow) can hand us a source whose VM was
+                // transplanted into the live drop target by a directional-split drop - it now has a parent.
+                // Tearing that down would destroy the drop target, so only tear down genuine abandoned
+                // roots (a real tearoff root is parentless; an emptied tab-add source is too).
+                if (vm.Parent == null)
+                {
+                    vm.Teardown();
+                }
+            }
+        }
+
         // ===========[ Display Building ]=====================================
 
         public T BuildNewDisplayElement<T>() where T : IDockableDisplayElement
@@ -520,10 +554,11 @@ namespace AJut.UX.Docking
             m_windowsToCloseSilently.AddRange(tearoffs);
             foreach (Window window in tearoffs)
             {
-                // Deregister the tearoff's zone(s) from m_rootDockZones too (see DoTearoffWindowClose).
+                // Deregister the tearoff's zone(s) from m_rootDockZones AND tear down their VM trees (see
+                // DoTearoffWindowClose). The trees are still intact here - nothing closed them first.
                 if (m_dockZoneMapping.TryGetValue(window, out List<DockZone> closingZones))
                 {
-                    this.DeRegisterRootDockZones(closingZones.ToArray());
+                    this.DeRegisterAndTeardownRootZones(closingZones.ToArray());
                 }
 
                 m_tearoffRootZones.Remove(window);
@@ -1623,10 +1658,11 @@ namespace AJut.UX.Docking
             m_windowsToCloseSilently.Add(sourceWindow);
             try
             {
-                // Deregister the tearoff's zone(s) from m_rootDockZones too (see DoTearoffWindowClose).
+                // Deregister the tearoff's zone(s) from m_rootDockZones AND tear down their VM trees (see
+                // DoTearoffWindowClose). The trees are still intact here - this path closes no content first.
                 if (m_dockZoneMapping.TryGetValue(sourceWindow, out List<DockZone> closingZones))
                 {
-                    this.DeRegisterRootDockZones(closingZones.ToArray());
+                    this.DeRegisterAndTeardownRootZones(closingZones.ToArray());
                 }
 
                 m_tearoffRootZones.Remove(sourceWindow);
@@ -1713,8 +1749,12 @@ namespace AJut.UX.Docking
                 // try to re-close it when the last hideable panel is removed.
                 m_windowsToCloseSilently.Add(window);
 
-                var allAdapters = TreeTraversal<DockZoneViewModel>.All(root)
-                    .SelectMany(z => z.DockedContent).ToList();
+                // Snapshot the VM subtree NOW: RequestCloseAllAndClear below dismantles the tree
+                // (children get detached, Parent nulled), so we must capture every zone up front to
+                // sever its Manager/Parent afterward - a walk from root would only reach the root by then.
+                var closingZoneVMs = TreeTraversal<DockZoneViewModel>.All(root).ToList();
+
+                var allAdapters = closingZoneVMs.SelectMany(z => z.DockedContent).ToList();
                 var hideable = allAdapters.Where(a => a.HideDontClose).ToList();
                 foreach (var adapter in hideable)
                 {
@@ -1734,6 +1774,14 @@ namespace AJut.UX.Docking
                 if (m_dockZoneMapping.TryGetValue(window, out List<DockZone> closingZones))
                 {
                     this.DeRegisterRootDockZones(closingZones.ToArray());
+                }
+
+                // Terminal teardown of the (now-dismantled) VM subtree captured above. Each zone is
+                // childless at this point, so Teardown just severs its Manager/Parent/UI - the content
+                // was already closed and disposed by RequestCloseAllAndClear.
+                foreach (DockZoneViewModel vm in closingZoneVMs)
+                {
+                    vm.Teardown();
                 }
 
                 m_tearoffRootZones.Remove(window);

--- a/libs/AJut.UX.WinUI3/Docking/DockingManager.cs
+++ b/libs/AJut.UX.WinUI3/Docking/DockingManager.cs
@@ -520,6 +520,12 @@ namespace AJut.UX.Docking
             m_windowsToCloseSilently.AddRange(tearoffs);
             foreach (Window window in tearoffs)
             {
+                // Deregister the tearoff's zone(s) from m_rootDockZones too (see DoTearoffWindowClose).
+                if (m_dockZoneMapping.TryGetValue(window, out List<DockZone> closingZones))
+                {
+                    this.DeRegisterRootDockZones(closingZones.ToArray());
+                }
+
                 m_tearoffRootZones.Remove(window);
                 m_dockZoneMapping.Remove(window);
                 m_windowManager.StopTracking(window);
@@ -1617,6 +1623,12 @@ namespace AJut.UX.Docking
             m_windowsToCloseSilently.Add(sourceWindow);
             try
             {
+                // Deregister the tearoff's zone(s) from m_rootDockZones too (see DoTearoffWindowClose).
+                if (m_dockZoneMapping.TryGetValue(sourceWindow, out List<DockZone> closingZones))
+                {
+                    this.DeRegisterRootDockZones(closingZones.ToArray());
+                }
+
                 m_tearoffRootZones.Remove(sourceWindow);
                 m_dockZoneMapping.Remove(sourceWindow);
                 m_windowManager.StopTracking(sourceWindow);  // unregisters Window.Closed so auto-cleanup won't double-fire
@@ -1655,6 +1667,10 @@ namespace AJut.UX.Docking
             {
                 panel.TitleBarDragInitiated -= this.OnTearoffPanelDragInitiated;
                 panel.CloseRequested -= this.OnTearoffPanelCloseRequested;
+
+                // Drop the panel's own AppWindow.Changed sub and its caption buttons' Window.Activated
+                // subs, so the closing window's native peer can't keep the panel + DockZone graph rooted.
+                panel.TeardownWindowHooks();
             }
         }
 
@@ -1710,6 +1726,14 @@ namespace AJut.UX.Docking
                 if (closeResult.HasErrors)
                 {
                     return false;
+                }
+
+                // Drop the tearoff's root zone(s) from m_rootDockZones too. Without this a closed
+                // tearoff's DockZone (and everything referenced through it) stays rooted by the manager
+                // for its whole life, growing m_rootDockZones one entry per tearoff open/close cycle.
+                if (m_dockZoneMapping.TryGetValue(window, out List<DockZone> closingZones))
+                {
+                    this.DeRegisterRootDockZones(closingZones.ToArray());
                 }
 
                 m_tearoffRootZones.Remove(window);

--- a/libs/AJut.UX.Wpf/Controls/PropertyGrid.cs
+++ b/libs/AJut.UX.Wpf/Controls/PropertyGrid.cs
@@ -49,6 +49,13 @@ namespace AJut.UX.Controls
                 this.OnSetPropertyToDefaultExecuted,
                 this.OnSetPropertyToDefaultCanExecute
             ));
+
+            // Drop the source -> grid PropertyChanged subscription whenever the grid leaves the
+            // visual tree, and restore it when it comes back. Without this a long-lived source
+            // object pins the whole grid after a consumer simply drops it (without Dispose or
+            // nulling the source) - see OnSourceItemPropertyChanged subscription below.
+            this.Loaded += this.OnLoaded;
+            this.Unloaded += this.OnUnloaded;
         }
 
         public void Dispose ()
@@ -234,6 +241,72 @@ namespace AJut.UX.Controls
             {
                 this.PART_TreeList.DragGhostTemplate = e.NewValue;
             }
+        }
+
+        // ===========[ Lifecycle - source subscription ]==========================
+        // The grid mirrors external edits by subscribing to its source object(s) PropertyChanged.
+        // That subscription is a source -> grid strong reference, so a long-lived source pins the
+        // grid once it leaves the tree (a consumer that drops the grid without Dispose or nulling
+        // the source). Toggle the subscription with tree membership: drop it on Unloaded so a
+        // dropped grid collects, restore + refresh it on Loaded so a re-shown grid stays live.
+        private void OnLoaded (object sender, RoutedEventArgs e)
+        {
+            this.UpdateSourceSubscription(subscribe: true);
+            this.RefreshAllTargets();
+        }
+
+        private void OnUnloaded (object sender, RoutedEventArgs e)
+        {
+            this.UpdateSourceSubscription(subscribe: false);
+        }
+
+        private void UpdateSourceSubscription (bool subscribe)
+        {
+            // Always detach first so re-entry / a sub already established when the source DP was set
+            // before load cannot double-subscribe.
+            if (this.SingleItemSource is INotifyPropertyChanged single)
+            {
+                single.PropertyChanged -= this.OnSourceItemPropertyChanged;
+                if (subscribe)
+                {
+                    single.PropertyChanged += this.OnSourceItemPropertyChanged;
+                }
+            }
+
+            if (this.ItemsSource != null)
+            {
+                // The ItemsSource collection's CollectionChanged is also a source -> grid link, so toggle
+                // it alongside the per-item PropertyChanged subs.
+                if (this.ItemsSource is INotifyCollectionChanged collectionChange)
+                {
+                    collectionChange.CollectionChanged -= this.NotifyCollectionChangedItemsSource_OnCollectionChanged;
+                    if (subscribe)
+                    {
+                        collectionChange.CollectionChanged += this.NotifyCollectionChangedItemsSource_OnCollectionChanged;
+                    }
+                }
+
+                foreach (INotifyPropertyChanged pc in this.ItemsSource.OfType<INotifyPropertyChanged>())
+                {
+                    pc.PropertyChanged -= this.OnSourceItemPropertyChanged;
+                    if (subscribe)
+                    {
+                        pc.PropertyChanged += this.OnSourceItemPropertyChanged;
+                    }
+                }
+            }
+        }
+
+        // Re-read every target's value in case the source changed while the grid was detached.
+        // Snapshots first - RecacheEditValue on a list target may rebuild children mid-enumeration.
+        private void RefreshAllTargets ()
+        {
+            foreach (var target in m_manager.Items.OfType<PropertyEditTarget>().ToArray())
+            {
+                target.RecacheEditValue();
+            }
+
+            m_manager.UpdateConditionalVisibility();
         }
 
         private void OnSingleItemSourceChanged (DependencyPropertyChangedEventArgs<object> e)

--- a/libs/AJut.UX.Wpf/Docking/DockingManager.cs
+++ b/libs/AJut.UX.Wpf/Docking/DockingManager.cs
@@ -95,6 +95,11 @@
                         this.StopTrackingSizingChanges(zone);
                     }
                 }
+
+                // Terminal teardown of the view-model tree: drop Manager/Parent/UI on every zone VM so a
+                // zone whose UI peer outlives this manager can't re-root the (now disposed) manager. The
+                // VM tree is still intact here - CloseAll(force) above only closed tearoff windows.
+                rootZone.ViewModel?.Teardown();
             }
 
             // Without this Dispose call the window manager's subs to root window events
@@ -590,6 +595,18 @@
                                     // won't traverse the stale tearoff root after content was moved
                                     var tearoffRoots = dragSourceWindow.GetVisualChildren().OfType<DockZone>().ToArray();
                                     this.DeRegisterRootDockZones(tearoffRoots);
+
+                                    // Terminal teardown of the abandoned source root(s). A directional-split
+                                    // drop transplants the dragged VM into the live drop target (it gains a
+                                    // parent), so only tear down a genuinely-abandoned (parentless) root -
+                                    // tearing down a transplanted VM would destroy the drop target.
+                                    foreach (DockZone tearoffRoot in tearoffRoots)
+                                    {
+                                        if (tearoffRoot.ViewModel != null && tearoffRoot.ViewModel.Parent == null)
+                                        {
+                                            tearoffRoot.ViewModel.Teardown();
+                                        }
+                                    }
 
                                     this.DetachTearoffSubscriptions(dragSourceWindow);
                                     dragSourceWindow.Close();
@@ -1207,8 +1224,12 @@
                 // try to re-close it when the last hideable panel is removed.
                 m_windowsToCloseSilently.Add(window);
 
-                var allAdapters = TreeTraversal<DockZoneViewModel>.All(root)
-                    .SelectMany(z => z.DockedContent).ToList();
+                // Snapshot the VM subtree NOW: RequestCloseAllAndClear below dismantles the tree
+                // (children get detached, Parent nulled), so we must capture every zone up front to
+                // sever its Manager/Parent afterward - a walk from root would only reach the root by then.
+                var closingZoneVMs = TreeTraversal<DockZoneViewModel>.All(root).ToList();
+
+                var allAdapters = closingZoneVMs.SelectMany(z => z.DockedContent).ToList();
                 var hideable = allAdapters.Where(a => a.HideDontClose).ToList();
                 foreach (var adapter in hideable)
                 {
@@ -1235,6 +1256,15 @@
                 // window object. Safe to -= from inside the handler - the current invocation
                 // completes regardless.
                 this.DetachTearoffSubscriptions(window);
+
+                // Terminal teardown of the (now-dismantled) VM subtree captured above. Each zone is
+                // childless at this point, so Teardown just severs its Manager/Parent/UI - the content
+                // was already closed and disposed by RequestCloseAllAndClear.
+                foreach (DockZoneViewModel vm in closingZoneVMs)
+                {
+                    vm.Teardown();
+                }
+
                 this.Windows.Root.Focus();
             }
             finally

--- a/libs/AJut.UX/Docking/DockZoneViewModel.cs
+++ b/libs/AJut.UX/Docking/DockZoneViewModel.cs
@@ -266,6 +266,7 @@ namespace AJut.UX.Docking
             {
                 dockedContent.InternalClose(true);
                 dockedContent.SetNewLocation(null);
+                dockedContent.Dispose();
             }
 
             if (this.Parent != null)
@@ -288,6 +289,14 @@ namespace AJut.UX.Docking
             }
             else if (orientation.IsFlagInGroup(eDockOrientation.AnySplitOrientation))
             {
+                // Detach each adapter before dropping it so it releases its back-reference to this
+                // zone (Location + the DockedContent CollectionChanged sub) instead of being orphaned
+                // with a live link. A split zone holds no docked content of its own.
+                foreach (var adapter in m_dockedContent.ToList())
+                {
+                    adapter.SetNewLocation(null);
+                }
+
                 m_dockedContent.Clear();
             }
 
@@ -386,7 +395,16 @@ namespace AJut.UX.Docking
 
             if (m_dockedContent.Contains(panelAdapter) && panelAdapter.Close())
             {
-                return this.DoRemoveContent(panelAdapter);
+                bool removed = this.DoRemoveContent(panelAdapter);
+                if (removed)
+                {
+                    // The panel was actually closed and removed (tearoff / relocation re-homes via
+                    // SetNewLocation and never calls Close, so it never lands here). Release the
+                    // adapter's event subscribers now that it is permanently gone.
+                    panelAdapter.Dispose();
+                }
+
+                return removed;
             }
 
             return false;

--- a/libs/AJut.UX/Docking/DockZoneViewModel.cs
+++ b/libs/AJut.UX/Docking/DockZoneViewModel.cs
@@ -365,6 +365,41 @@ namespace AJut.UX.Docking
             }
         }
 
+        /// <summary>
+        /// Terminal teardown for a zone the docking manager is permanently dropping (its Dispose, or a
+        /// tearoff window closing for good). Severs every zone in this subtree from the manager, its
+        /// parent, and its UI so a zone whose native peer - or a stray delegate - outlives the logical
+        /// tree can no longer root the manager (and through it the whole docked graph). Any content still
+        /// docked is closed and disposed so its adapter releases its subscribers.
+        ///
+        /// This is deliberately NOT one of the move/reconfigure helpers (<see cref="RunChildZoneRemoval"/>,
+        /// <see cref="DestroyUIReference"/>, <see cref="ForceCloseAllAndClear"/>) - those are reused to
+        /// detach-then-rehome a zone and must leave Manager/Parent intact. Only call this when the zone is
+        /// gone for good.
+        /// </summary>
+        public void Teardown ()
+        {
+            // Snapshot the whole subtree first - the per-zone clear below drops the Parent/Children links,
+            // so a walk afterward would strand (and fail to sever) the deeper zones. This also means the
+            // caller can hand us a tree a close path has already partly dismantled and we still cover it.
+            foreach (DockZoneViewModel zone in TreeTraversal<DockZoneViewModel>.All(this).ToList())
+            {
+                foreach (DockingContentAdapterModel adapter in zone.m_dockedContent.ToList())
+                {
+                    adapter.InternalClose(true);
+                    adapter.SetNewLocation(null);
+                    adapter.Dispose();
+                }
+
+                zone.m_dockedContent.Clear();
+                zone.m_children.Clear();
+                zone.Orientation = eDockOrientation.Empty;
+                zone.UI = null;
+                zone.Parent = null;
+                zone.Manager = null;
+            }
+        }
+
         public bool RemoveDockedContent (DockingContentAdapterModel contentAdapter)
         {
             bool orphanedAfter = m_manager.IsTearoffRootThatWouldOrphan(this);

--- a/libs/AJut.UX/Docking/DockingContentAdapterModel.cs
+++ b/libs/AJut.UX/Docking/DockingContentAdapterModel.cs
@@ -29,6 +29,16 @@ namespace AJut.UX.Docking
             {
                 locationCollection.CollectionChanged -= this.OnOrderChangedInDockZone;
             }
+
+            // Release every event subscriber. A panel routinely subscribes its own methods/lambdas to
+            // CanClose (veto) and Closed (cleanup) in Setup; if those are left attached, this adapter
+            // pins the panel (and everything it reaches) through the delegate's target after the panel
+            // is gone. Called from the permanent-close paths (see DockZoneViewModel).
+            this.SetupComplete = null;
+            this.Docked = null;
+            this.TabOrderChanged = null;
+            this.CanClose = null;
+            this.Closed = null;
         }
 
         // ===========[ Events ]===================================

--- a/test/AJut.UX.Tests/DockingTeardownTests.cs
+++ b/test/AJut.UX.Tests/DockingTeardownTests.cs
@@ -1,0 +1,97 @@
+namespace AJut.UX.Tests
+{
+    using System;
+    using AJut.UX.Docking;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    // Headless teardown/leak regressions for the platform-agnostic docking model. Each asserts the
+    // post-teardown state deterministically (weak reference + forced GC), so they run with no UI host.
+    [TestClass]
+    public class DockingTeardownTests
+    {
+        // AM-1: A docked panel routinely subscribes to its adapter's CanClose (veto) and Closed
+        // (cleanup) events in Setup. When the panel is closed and removed, the adapter must release
+        // those subscribers - otherwise a lingering adapter pins the panel (and everything it reaches)
+        // through the event delegate's target. This is the consumer-facing shape of the leak.
+        [TestMethod]
+        public void ClosingDockedContent_ReleasesAdapterEventSubscribers ()
+        {
+            var zone = new DockZoneViewModel(manager: null);
+            var adapter = new DockingContentAdapterModel(null);
+            WeakReference weakSubscriber = AttachVetoSubscriberAndForget(adapter);
+
+            zone.AddDockedContent(adapter);
+            bool closed = zone.RequestCloseAndRemoveDockedContent(adapter);
+
+            Assert.IsTrue(closed, "the panel should have closed cleanly (no veto)");
+            ForceFullCollect();
+            Assert.IsFalse(
+                weakSubscriber.IsAlive,
+                "closing a docked panel must release its adapter's CanClose/Closed subscribers so the panel can collect"
+            );
+        }
+
+        // AM-1 (method contract): Dispose() is the adapter's teardown. It must release every event
+        // subscriber, not just the internal CollectionChanged hook, so a disposed adapter pins nothing.
+        [TestMethod]
+        public void DisposingAdapter_ReleasesEventSubscribers ()
+        {
+            var adapter = new DockingContentAdapterModel(null);
+            WeakReference weakSubscriber = AttachVetoSubscriberAndForget(adapter);
+
+            adapter.Dispose();
+
+            ForceFullCollect();
+            Assert.IsFalse(
+                weakSubscriber.IsAlive,
+                "DockingContentAdapterModel.Dispose() must release event subscribers, not just the CollectionChanged hook"
+            );
+        }
+
+        // VM-2: Configuring a leaf zone that still holds docked content into a split orientation clears
+        // the docked content. It must DETACH those adapters (SetNewLocation(null)) first, not silently
+        // drop them - otherwise each orphaned adapter keeps Location pointing at the zone and its
+        // DockedContent CollectionChanged subscription attached.
+        [TestMethod]
+        public void ConfiguringLeafIntoSplit_DetachesDockedAdapters ()
+        {
+            var zone = new DockZoneViewModel(manager: null);
+            var adapter = new DockingContentAdapterModel(null);
+            zone.AddDockedContent(adapter);
+            Assert.AreSame(zone, adapter.Location, "sanity: the adapter is docked into the zone");
+
+            zone.Configure(eDockOrientation.Horizontal);
+
+            Assert.IsNull(
+                adapter.Location,
+                "configuring a content-bearing leaf into a split must detach its adapters, not orphan them with a live back-reference"
+            );
+        }
+
+        // The subscriber's only reference is the adapter's event delegate, so its collection proves the
+        // adapter let go.
+        private static WeakReference AttachVetoSubscriberAndForget (DockingContentAdapterModel adapter)
+        {
+            var subscriber = new PanelSubscriberStandin();
+            adapter.CanClose += subscriber.OnCanClose;
+            adapter.Closed += subscriber.OnClosed;
+            return new WeakReference(subscriber);
+        }
+
+        private static void ForceFullCollect ()
+        {
+            for (int i = 0; i < 2; ++i)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
+        }
+
+        private sealed class PanelSubscriberStandin
+        {
+            public void OnCanClose (object sender, IsReadyToCloseEventArgs e) { /* allow the close */ }
+            public void OnClosed (object sender, ClosedEventArgs e) { }
+        }
+    }
+}

--- a/test/AJut.UX.Tests/DockingTeardownTests.cs
+++ b/test/AJut.UX.Tests/DockingTeardownTests.cs
@@ -1,6 +1,7 @@
 namespace AJut.UX.Tests
 {
     using System;
+    using System.Collections.Generic;
     using AJut.UX.Docking;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -68,6 +69,73 @@ namespace AJut.UX.Tests
             );
         }
 
+        // VM-1: When the manager permanently drops a zone it must sever Manager/Parent on EVERY zone in
+        // the subtree, not just the root. A zone whose native peer (or a stray delegate) outlives the
+        // logical tree would otherwise re-root the manager through Manager - and the whole graph through
+        // the parent chain. Teardown is the manager-driven terminal sweep that breaks both links.
+        [TestMethod]
+        public void TearingDownZone_SeversManagerAndParentForEveryZoneInTheTree ()
+        {
+            var manager = new InertDockingManager();
+            var root = new DockZoneViewModel(manager);
+            root.Configure(eDockOrientation.Horizontal);
+
+            var leafA = new DockZoneViewModel(manager);
+            leafA.AddDockedContent(new DockingContentAdapterModel(null));
+            var leafB = new DockZoneViewModel(manager);
+            leafB.AddDockedContent(new DockingContentAdapterModel(null));
+            root.AddChild(leafA);
+            root.AddChild(leafB);
+
+            Assert.AreSame(manager, leafA.Manager, "sanity: a child picks up the manager when added");
+            Assert.AreSame(root, leafA.Parent, "sanity: a child is parented under root when added");
+
+            root.Teardown();
+
+            Assert.IsNull(root.Manager, "the root must drop its manager on teardown");
+            Assert.IsNull(leafA.Manager, "every descendant must drop its manager on teardown");
+            Assert.IsNull(leafB.Manager, "every descendant must drop its manager on teardown");
+            Assert.IsNull(leafA.Parent, "every descendant must drop its parent on teardown");
+            Assert.IsNull(leafB.Parent, "every descendant must drop its parent on teardown");
+        }
+
+        // VM-1 (the leak shape): the consumer-facing failure is a single zone the manager already dropped
+        // still pinning the manager. After teardown a surviving leaf must root neither the manager nor its
+        // former ancestors, so both collect even while the leaf is held alive.
+        [TestMethod]
+        public void TearingDownZone_LeavesNoUpwardReferenceFromASurvivingZone ()
+        {
+            DockZoneViewModel survivor = BuildAndTeardownTreeKeepingOneLeaf(out WeakReference weakManager, out WeakReference weakRoot);
+
+            ForceFullCollect();
+
+            GC.KeepAlive(survivor);
+            Assert.IsFalse(weakManager.IsAlive, "a torn-down zone must not keep the manager rooted");
+            Assert.IsFalse(weakRoot.IsAlive, "a torn-down zone must not keep its old root / ancestors rooted");
+        }
+
+        // Builds a small tree, tears it down, and hands back one leaf as the "stuck" survivor. The manager
+        // and root locals fall out of scope on return, so only the leaf could still be rooting them.
+        private static DockZoneViewModel BuildAndTeardownTreeKeepingOneLeaf (out WeakReference weakManager, out WeakReference weakRoot)
+        {
+            var manager = new InertDockingManager();
+            var root = new DockZoneViewModel(manager);
+            root.Configure(eDockOrientation.Horizontal);
+
+            var leafA = new DockZoneViewModel(manager);
+            leafA.AddDockedContent(new DockingContentAdapterModel(null));
+            var leafB = new DockZoneViewModel(manager);
+            leafB.AddDockedContent(new DockingContentAdapterModel(null));
+            root.AddChild(leafA);
+            root.AddChild(leafB);
+
+            weakManager = new WeakReference(manager);
+            weakRoot = new WeakReference(root);
+
+            root.Teardown();
+            return leafA;
+        }
+
         // The subscriber's only reference is the adapter's event delegate, so its collection proves the
         // adapter let go.
         private static WeakReference AttachVetoSubscriberAndForget (DockingContentAdapterModel adapter)
@@ -92,6 +160,32 @@ namespace AJut.UX.Tests
         {
             public void OnCanClose (object sender, IsReadyToCloseEventArgs e) { /* allow the close */ }
             public void OnClosed (object sender, ClosedEventArgs e) { }
+        }
+
+        // Inert IDockingManager: the model-layer teardown never calls back into the manager, so every
+        // member can throw. It exists only so a zone can hold a non-null Manager we can prove gets nulled
+        // (and so we can weak-reference it to prove a torn-down zone stops rooting it).
+        private sealed class InertDockingManager : IDockingManager
+        {
+            public double MinPanelDimension { get; set; }
+            public DockPanelAddRemoveUISync UISyncVM => throw new NotImplementedException();
+            public IDockableDisplayElement BuildNewDisplayElement (Type elementType) => throw new NotImplementedException();
+            public IEnumerable<DockZoneViewModel> GetAllRoots () => throw new NotImplementedException();
+            public bool LoadDockLayoutFromFile (string filePath) => throw new NotImplementedException();
+            public bool SaveDockLayoutToFile (string filePath = null) => throw new NotImplementedException();
+            public bool SaveDockLayoutToPersistentStorage () => throw new NotImplementedException();
+            public bool ReloadDockLayoutFromPersistentStorage () => throw new NotImplementedException();
+            public void AddPanel (Type panelType) => throw new NotImplementedException();
+            public void TogglePanel (Type panelType) => throw new NotImplementedException();
+            public void RemoveOrHidePanel (DockingContentAdapterModel adapter) => throw new NotImplementedException();
+            public DockPanelRegistrationRules? GetPanelRules (Type panelType) => throw new NotImplementedException();
+            public DockZoneViewModel FindTargetZoneForGroup (string groupId) => throw new NotImplementedException();
+            public HiddenPanelPlatformState CaptureHideState (DockingContentAdapterModel adapter) => throw new NotImplementedException();
+            public bool TryRestoreFromHideState (object hideState, DockingContentAdapterModel adapter) => throw new NotImplementedException();
+            public void AfterPanelHidden (object hideState) => throw new NotImplementedException();
+            public bool CreateTearoffForPanel (DockingContentAdapterModel adapter, double x, double y, double width, double height) => throw new NotImplementedException();
+            public bool IsTearoffRootThatWouldOrphan (DockZoneViewModel zone) => throw new NotImplementedException();
+            public void CloseTearoffForRootZone (DockZoneViewModel rootZone) => throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Utilizing my winui setup for testing in real world situations, I was able to find a few more situations where memory leaks could occur. After fixing I did a similar wpf port, but in actuality wpf does not have the same problems due to differences in construction.